### PR TITLE
[chore] Spring Security 설정 정보 위치 이동

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/CustomUserDetailService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/CustomUserDetailService.java
@@ -1,4 +1,4 @@
-package chungbazi.chungbazi_be.global.auth;
+package chungbazi.chungbazi_be.domain.auth;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/chungbazi/chungbazi_be/global/auth/CustomUserDetailService.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/auth/CustomUserDetailService.java
@@ -1,4 +1,4 @@
-package chungbazi.chungbazi_be.config;
+package chungbazi.chungbazi_be.global.auth;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/chungbazi/chungbazi_be/global/config/SecurityConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package chungbazi.chungbazi_be.config;
+package chungbazi.chungbazi_be.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/chungbazi/chungbazi_be/global/config/SecurityConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/SecurityConfig.java
@@ -19,8 +19,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/","/login").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .logout(logout -> logout
                         .logoutUrl("/logout")


### PR DESCRIPTION
## 연관 이슈

close #5

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
SpringSecurity 설정 정보 위치 이동

<br/>

## ✅ 작업 내용

- [x] SecurityConfig -> global/config로 이동
- [x] CustomUserDetailService -> domain/auth로 이동
- [x] SecurityConfig - anyRequest permitAll

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
