### PR TITLE
[feature] 알림 조회 API (#33)

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
     private final NotificationService notificationService;
 
-    @PostMapping
+    @PostMapping("/create")
     @Operation(summary = "알림 생성 API", description = "알림을 생성하고, fcm으로 알림을 요청하는 API입니다.")
     public ApiResponse<NotificationResponseDTO.responseDto> createNotification(@RequestBody NotificationRequestDTO.createDTO dto) {
         NotificationResponseDTO.responseDto responseDto = notificationService.sendNotification(dto);
@@ -29,15 +29,14 @@ public class NotificationController {
         return ApiResponse.onSuccess(null);
     }
 
-    @GetMapping("/{userId}")
+    @GetMapping
     @Operation(summary = "알림 조회 API",description = "알림을 조회하는 API입니다. 전체 알림을 조회하고 싶으면 type 입력을 안하시면 됩니당. 캘린더 알림 조회 시 type에 POLICY_ALARM을 커뮤니티 알림 조회 시에는 COMMUNITY_ALARM을 선택해주세요")
     public ApiResponse<NotificationResponseDTO.notificationListDto> getNotifications(
-            @PathVariable Long userId,
             @RequestParam(required = false) NotificationType type,
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "15") int limit){
 
-        NotificationResponseDTO.notificationListDto response=notificationService.getNotifications(userId,type,cursor,limit);
+        NotificationResponseDTO.notificationListDto response=notificationService.getNotifications(type,cursor,limit);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package chungbazi.chungbazi_be.domain.notification.controller;
 
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationRequestDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationResponseDTO;
+import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 import chungbazi.chungbazi_be.domain.notification.service.NotificationService;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,4 +28,20 @@ public class NotificationController {
         notificationService.markAsRead(notificationId);
         return ApiResponse.onSuccess(null);
     }
+
+    @GetMapping("/{userId}")
+    @Operation(summary = "알림 조회 API",description = "알림을 조회하는 API입니다. 전체 알림을 조회하고 싶으면 type 입력을 안하시면 됩니당. 캘린더 알림 조회 시 type에 POLICY_ALARM을 커뮤니티 알림 조회 시에는 COMMUNITY_ALARM을 선택해주세요")
+    public ApiResponse<NotificationResponseDTO.notificationListDto> getNotifications(
+            @PathVariable Long userId,
+            @RequestParam(required = false) NotificationType type,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "15") int limit){
+
+        NotificationResponseDTO.notificationListDto response=notificationService.getNotifications(userId,type,cursor,limit);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,16 @@
+package chungbazi.chungbazi_be.domain.notification.converter;
+
+import chungbazi.chungbazi_be.domain.notification.dto.NotificationResponseDTO;
+import chungbazi.chungbazi_be.domain.notification.entity.Notification;
+
+public class NotificationConverter {
+
+    public static NotificationResponseDTO.notificationDto toNotificationDto(Notification notification){
+        return NotificationResponseDTO.notificationDto.builder()
+                .notificationId(notification.getId())
+                .isRead(notification.isRead())
+                .message(notification.getMessage())
+                .type(notification.getType())
+                .build();
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationRequestDTO.java
@@ -8,7 +8,6 @@ public class NotificationRequestDTO {
 
     @Getter
     public static class createDTO {
-        private Long userId;
         private NotificationType type;
         private String message;
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
@@ -39,6 +39,7 @@ public class NotificationResponseDTO {
     public static class notificationListDto{
         private List<notificationDto> notifications;
         private Long nextCursor;
+        private boolean hasNext;
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 public class NotificationResponseDTO {
@@ -29,6 +30,15 @@ public class NotificationResponseDTO {
         private boolean isRead;
         private String message;
         private NotificationType type;
-        private LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class notificationListDto{
+        private List<notificationDto> notifications;
+        private Long nextCursor;
+    }
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepository.java
@@ -4,6 +4,9 @@ import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends JpaRepository<Notification, Long>,NotificationRepositoryCustom {
+    List<Notification> findAllByUserId(Long userId);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,11 +1,17 @@
 package chungbazi.chungbazi_be.domain.notification.repository;
 
 
+import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 
+
+import java.util.List;
 
 
 public interface NotificationRepositoryCustom {
 
     void markAllAsRead(Long userId,NotificationType type);
+
+    List<Notification> findNotificationsByUserIdAndNotificationType(Long userId, NotificationType type, Long cursor, int limit);
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package chungbazi.chungbazi_be.domain.notification.repository;
+
+
+import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
+
+
+
+public interface NotificationRepositoryCustom {
+
+    void markAllAsRead(Long userId,NotificationType type);
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,36 @@
+package chungbazi.chungbazi_be.domain.notification.repository;
+
+import chungbazi.chungbazi_be.domain.notification.entity.Notification;
+import chungbazi.chungbazi_be.domain.notification.entity.QNotification;
+import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
+import com.google.api.gax.paging.Page;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QNotification qNotification=QNotification.notification;
+
+
+        //알림 읽음 처리
+    @Override
+    public void markAllAsRead(Long userId, NotificationType type){
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        booleanBuilder.and(qNotification.user.id.eq(userId));
+        booleanBuilder.and(qNotification.isRead.eq(false));
+
+        if (type!=null){
+            booleanBuilder.and(qNotification.type.eq(type));
+        }
+
+        queryFactory.update(qNotification)
+                .set(qNotification.isRead,true)
+                .where(booleanBuilder)
+                .execute();
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
@@ -7,19 +7,24 @@ import com.google.api.gax.paging.Page;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class NotificationRepositoryImpl implements NotificationRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
-    private final QNotification qNotification=QNotification.notification;
 
 
-        //알림 읽음 처리
+    //알림 읽음 처리
     @Override
     public void markAllAsRead(Long userId, NotificationType type){
+
+        QNotification qNotification=QNotification.notification;
+
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(qNotification.user.id.eq(userId));
         booleanBuilder.and(qNotification.isRead.eq(false));
@@ -33,4 +38,34 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom{
                 .where(booleanBuilder)
                 .execute();
     }
+
+    //알림 조회
+    @Override
+    public List<Notification> findNotificationsByUserIdAndNotificationType(Long userId, NotificationType type, Long cursor, int limit) {
+
+        QNotification qNotification=QNotification.notification;
+
+        BooleanBuilder booleanBuilder=new BooleanBuilder();
+        booleanBuilder.and(qNotification.user.id.eq(userId));
+
+        //타입필터
+        if(type!=null){
+            booleanBuilder.and(qNotification.type.eq(type));
+        }
+        if(cursor!=null){
+            booleanBuilder.and(qNotification.id.lt(cursor));
+        }
+
+        //페이징 조회
+        List<Notification> notifications=queryFactory
+                .selectFrom(qNotification)
+                .where(booleanBuilder)
+                .orderBy(qNotification.createdAt.desc())
+                .limit(limit)
+                .fetch();
+
+        return notifications;
+    }
+
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -97,7 +97,9 @@ public class NotificationService {
         List<Notification> notificationList = notificationRepository.findNotificationsByUserIdAndNotificationType(userId, type, cursor, limit + 1);
 
         Long nextCursor = null;
-        if (notificationList.size() > limit) {
+        boolean hasNext=notificationList.size() > limit;
+
+        if (hasNext) {
             Notification lastNotification = notificationList.get(limit - 1);
             nextCursor = lastNotification.getId();
             notificationList = notificationList.subList(0, limit);
@@ -110,6 +112,7 @@ public class NotificationService {
         return NotificationResponseDTO.notificationListDto.builder()
                 .notifications(notificationDtos)
                 .nextCursor(nextCursor)
+                .hasNext(hasNext)
                 .build();
 
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package chungbazi.chungbazi_be.domain.notification.service;
 
+import chungbazi.chungbazi_be.domain.auth.jwt.SecurityUtils;
 import chungbazi.chungbazi_be.domain.notification.converter.NotificationConverter;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationRequestDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationResponseDTO;
@@ -8,7 +9,6 @@ import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 import chungbazi.chungbazi_be.domain.notification.repository.NotificationRepository;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.repository.UserRepository;
-import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -33,7 +33,7 @@ public class NotificationService {
 
     public NotificationResponseDTO.responseDto sendNotification(NotificationRequestDTO.createDTO dto) {
         //알림 생성
-        User user = userRepository.findById(dto.getUserId())
+        User user = userRepository.findById(SecurityUtils.getUserId())
                 .orElseThrow(()->new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
         Notification notification=Notification.builder()
                 .user(user)
@@ -84,7 +84,12 @@ public class NotificationService {
     }
 
     //알림 조회
-    public NotificationResponseDTO.notificationListDto getNotifications(Long userId, NotificationType type, Long cursor, int limit) {
+    public NotificationResponseDTO.notificationListDto getNotifications(NotificationType type, Long cursor, int limit) {
+
+        Long userId= SecurityUtils.getUserId();
+        if(userId==null || userId <= 0){
+            throw new NotFoundHandler(ErrorStatus.NOT_FOUND_USER);
+        }
 
         //알림 읽음 처리
         notificationRepository.markAllAsRead(userId, type);

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandle
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class NotificationService {
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
           time_zone: Asia/Seoul
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 server:


### PR DESCRIPTION
## 연관 이슈

close #33

<br/>

## 개요

알림을 조회하는 api를 구현했습니다.
우선 프론트와 얘기해본 결과 알림 페이지로 이동하면, 그때 알림을 다 확인했다고 가정하자해서 관련 로직을 구현했습니다

그리고 처음에는 전체 알림 조회, 카테고리 별 알림 조회를 따로 구현하려 했는데, type만 달라지는 거라 type 선택을 안 할 시엔 전체 알림을, 각 카테고리 별로 선택 시엔 카테고리 알림만 조회할 수 있도록 구현했습니다 노션 api설계서에도 반영해두겠습니당

<img width="717" alt="스크린샷 2025-01-28 오후 10 48 12" src="https://github.com/user-attachments/assets/583909f2-144a-4bf8-b588-a26d297617ee" />
<img width="716" alt="스크린샷 2025-01-28 오후 10 48 22" src="https://github.com/user-attachments/assets/e45a8e7d-2e9e-478a-86c7-602e75ee2a5a" />
<img width="712" alt="스크린샷 2025-01-28 오후 10 48 48" src="https://github.com/user-attachments/assets/5e6fbd93-02f3-4436-88e2-cfbae0d9814d" />

테스트 결과 세개 다 잘 돌아가는 거 확인했습니당



<br/>

## ✅ 작업 내용

- [x] 알림 페이지 확인 시 알림 전부 읽음 처리
- [x] 알림 조회 로직 구현

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

프론트 측에서 페이징처리를 해달라고 하셔서 cursor 이용한 무한 스크롤방식을 사용하였는데 cursor 부분 코드가 맞게 구현된건지 체크 부탁드립니다!!
