### PR TITLE
[feature] 마이페이지 유저 정보 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,33 +45,35 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-crypto'
   
-  // WebClient
-  implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
   
-  // Jackson XML (XML->Java)
+    // Jackson XML (XML->Java)
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
   
-  // ARM 기반의 칩에 네이티브 라이브러리 설정
+    // ARM 기반의 칩에 네이티브 라이브러리 설정
 	runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.96.Final:osx-aarch_64'
   
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
-  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
   
-  // JSON Web Tokens (JWT) for authentication
+    // JSON Web Tokens (JWT) for authentication
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-  // QueryDsl
-  implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-  annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-  annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-  annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	/* S3 관련 */
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 //tasks.named('test') {

--- a/src/main/generated/chungbazi/chungbazi_be/domain/notification/entity/QNotification.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/notification/entity/QNotification.java
@@ -58,7 +58,7 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user")) : null;
+        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
     }
 
 }

--- a/src/main/generated/chungbazi/chungbazi_be/domain/user/entity/QUser.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/user/entity/QUser.java
@@ -18,6 +18,8 @@ public class QUser extends EntityPathBase<User> {
 
     private static final long serialVersionUID = 305651281L;
 
+    private static final PathInits INITS = PathInits.DIRECT2;
+
     public static final QUser user = new QUser("user");
 
     public final EnumPath<chungbazi.chungbazi_be.domain.user.entity.enums.Education> education = createEnum("education", chungbazi.chungbazi_be.domain.user.entity.enums.Education.class);
@@ -27,8 +29,6 @@ public class QUser extends EntityPathBase<User> {
     public final EnumPath<chungbazi.chungbazi_be.domain.user.entity.enums.Employment> employment = createEnum("employment", chungbazi.chungbazi_be.domain.user.entity.enums.Employment.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
-
-    public final StringPath imageUrl = createString("imageUrl");
 
     public final EnumPath<chungbazi.chungbazi_be.domain.user.entity.enums.Income> income = createEnum("income", chungbazi.chungbazi_be.domain.user.entity.enums.Income.class);
 
@@ -40,6 +40,8 @@ public class QUser extends EntityPathBase<User> {
 
     public final EnumPath<chungbazi.chungbazi_be.domain.user.entity.enums.OAuthProvider> oAuthProvider = createEnum("oAuthProvider", chungbazi.chungbazi_be.domain.user.entity.enums.OAuthProvider.class);
 
+    public final StringPath profileImg = createString("profileImg");
+
     public final EnumPath<chungbazi.chungbazi_be.domain.user.entity.enums.Region> region = createEnum("region", chungbazi.chungbazi_be.domain.user.entity.enums.Region.class);
 
     public final NumberPath<Integer> reward = createNumber("reward", Integer.class);
@@ -48,16 +50,27 @@ public class QUser extends EntityPathBase<User> {
 
     public final ListPath<chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest, chungbazi.chungbazi_be.domain.user.entity.mapping.QUserInterest> userInterestList = this.<chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest, chungbazi.chungbazi_be.domain.user.entity.mapping.QUserInterest>createList("userInterestList", chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest.class, chungbazi.chungbazi_be.domain.user.entity.mapping.QUserInterest.class, PathInits.DIRECT2);
 
+    public final chungbazi.chungbazi_be.global.entity.QUuid uuid;
+
     public QUser(String variable) {
-        super(User.class, forVariable(variable));
+        this(User.class, forVariable(variable), INITS);
     }
 
     public QUser(Path<? extends User> path) {
-        super(path.getType(), path.getMetadata());
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
     }
 
     public QUser(PathMetadata metadata) {
-        super(User.class, metadata);
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.uuid = inits.isInitialized("uuid") ? new chungbazi.chungbazi_be.global.entity.QUuid(forProperty("uuid")) : null;
     }
 
 }

--- a/src/main/generated/chungbazi/chungbazi_be/domain/user/entity/mapping/QUserAddition.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/user/entity/mapping/QUserAddition.java
@@ -47,7 +47,7 @@ public class QUserAddition extends EntityPathBase<UserAddition> {
     public QUserAddition(Class<? extends UserAddition> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.addition = inits.isInitialized("addition") ? new chungbazi.chungbazi_be.domain.user.entity.QAddition(forProperty("addition")) : null;
-        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user")) : null;
+        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
     }
 
 }

--- a/src/main/generated/chungbazi/chungbazi_be/domain/user/entity/mapping/QUserInterest.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/user/entity/mapping/QUserInterest.java
@@ -47,7 +47,7 @@ public class QUserInterest extends EntityPathBase<UserInterest> {
     public QUserInterest(Class<? extends UserInterest> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.interest = inits.isInitialized("interest") ? new chungbazi.chungbazi_be.domain.user.entity.QInterest(forProperty("interest")) : null;
-        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user")) : null;
+        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
     }
 
 }

--- a/src/main/generated/chungbazi/chungbazi_be/global/entity/QUuid.java
+++ b/src/main/generated/chungbazi/chungbazi_be/global/entity/QUuid.java
@@ -1,0 +1,39 @@
+package chungbazi.chungbazi_be.global.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUuid is a Querydsl query type for Uuid
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUuid extends EntityPathBase<Uuid> {
+
+    private static final long serialVersionUID = 1862406087L;
+
+    public static final QUuid uuid1 = new QUuid("uuid1");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath uuid = createString("uuid");
+
+    public QUuid(String variable) {
+        super(Uuid.class, forVariable(variable));
+    }
+
+    public QUuid(Path<? extends Uuid> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUuid(PathMetadata metadata) {
+        super(Uuid.class, metadata);
+    }
+
+}
+

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
@@ -20,6 +20,11 @@ public class UserController {
     public ApiResponse<UserResponseDTO.ProfileDto> getProfile() {
         return ApiResponse.onSuccess(userService.getProfile());
     }
+    @GetMapping("/profile/update")
+    @Operation(summary = "프로필 수정 API", description = "마이페이지 프로필 수정")
+    public ApiResponse<UserResponseDTO.ProfileUpdateDto> updateProfile(@PathVariable String newName) {
+        return ApiResponse.onSuccess(userService.updateProfile(newName));
+    }
 
     @PostMapping("/register")
     @Operation(summary = "사용자 정보 등록 API", description = "사용자 정보(지역, 취업상태, 소득, 추가사항, 관심사, 학력) 등록")

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
@@ -22,7 +22,7 @@ public class UserController {
     public ApiResponse<UserResponseDTO.ProfileDto> getProfile() {
         return ApiResponse.onSuccess(userService.getProfile());
     }
-    @PostMapping("/profile/update")
+    @PatchMapping(value = "/profile/update", consumes = "multipart/form-data")
     @Operation(summary = "프로필 수정 API", description = "마이페이지 프로필 수정")
     public ApiResponse<UserResponseDTO.ProfileUpdateDto> updateProfile(
             @RequestPart("info") @Valid UserRequestDTO.ProfileUpdateDto profileUpdateDto,

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import chungbazi.chungbazi_be.domain.user.service.UserService;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
 import chungbazi.chungbazi_be.global.validation.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,10 +21,10 @@ public class UserController {
     public ApiResponse<UserResponseDTO.ProfileDto> getProfile() {
         return ApiResponse.onSuccess(userService.getProfile());
     }
-    @GetMapping("/profile/update")
+    @PostMapping("/profile/update")
     @Operation(summary = "프로필 수정 API", description = "마이페이지 프로필 수정")
-    public ApiResponse<UserResponseDTO.ProfileUpdateDto> updateProfile(@PathVariable String newName) {
-        return ApiResponse.onSuccess(userService.updateProfile(newName));
+    public ApiResponse<UserResponseDTO.ProfileUpdateDto> updateProfile(@Valid @RequestBody UserRequestDTO.ProfileUpdateDto profileUpdateDto) {
+        return ApiResponse.onSuccess(userService.updateProfile(profileUpdateDto));
     }
 
     @PostMapping("/register")

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,8 +24,10 @@ public class UserController {
     }
     @PostMapping("/profile/update")
     @Operation(summary = "프로필 수정 API", description = "마이페이지 프로필 수정")
-    public ApiResponse<UserResponseDTO.ProfileUpdateDto> updateProfile(@Valid @RequestBody UserRequestDTO.ProfileUpdateDto profileUpdateDto) {
-        return ApiResponse.onSuccess(userService.updateProfile(profileUpdateDto));
+    public ApiResponse<UserResponseDTO.ProfileUpdateDto> updateProfile(
+            @RequestPart("info") @Valid UserRequestDTO.ProfileUpdateDto profileUpdateDto,
+            @RequestPart(value = "profileImg", required = false) MultipartFile profileImg) {
+        return ApiResponse.onSuccess(userService.updateProfile(profileUpdateDto, profileImg));
     }
 
     @PostMapping("/register")

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/converter/UserConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/converter/UserConverter.java
@@ -11,4 +11,10 @@ public class UserConverter {
                 .email(user.getEmail())
                 .build();
     }
+    public static UserResponseDTO.ProfileUpdateDto toProfileUpdateDto(User user){
+        return UserResponseDTO.ProfileUpdateDto.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .build();
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/converter/UserConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/converter/UserConverter.java
@@ -9,12 +9,14 @@ public class UserConverter {
                 .userId(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
+                .profileImg(user.getProfileImg())
                 .build();
     }
     public static UserResponseDTO.ProfileUpdateDto toProfileUpdateDto(User user){
         return UserResponseDTO.ProfileUpdateDto.builder()
                 .userId(user.getId())
                 .name(user.getName())
+                .profileImg(user.getProfileImg())
                 .build();
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserRequestDTO.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,6 +40,14 @@ public class UserRequestDTO {
 
         @Schema(example = "[\"중소기업\", \"여성\", \"저소득층\"]", description = "추가 정보")
         private List<String> additionInfo;
+    }
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileUpdateDto {
+        @NotBlank
+        @Size(min = 1, max = 10, message = "닉네임은 10자 이하")
+        String name;
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserResponseDTO.java
@@ -20,6 +20,7 @@ public class UserResponseDTO {
     public static class ProfileUpdateDto {
         Long userId;
         String name;
+        String profileImg;
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserResponseDTO.java
@@ -13,6 +13,7 @@ public class UserResponseDTO {
         Long userId;
         String name;
         String email;
+        String profileImg;
     }
     @Getter
     @Builder

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/UserResponseDTO.java
@@ -14,5 +14,12 @@ public class UserResponseDTO {
         String name;
         String email;
     }
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ProfileUpdateDto {
+        Long userId;
+        String name;
+    }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.user.entity.enums.*;
 import chungbazi.chungbazi_be.domain.user.entity.mapping.UserAddition;
 import chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest;
+import chungbazi.chungbazi_be.global.entity.Uuid;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -54,7 +55,13 @@ public class User {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    private String imageUrl;
+    @Column
+    @Setter
+    private String profileImg;
+
+    @OneToOne
+    @JoinColumn(name = "uuid_id")
+    private Uuid uuid;
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = {CascadeType.ALL})

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
@@ -26,6 +26,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -55,13 +55,19 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
-        if(profileImg.getSize() > MAX_UPLOAD_SIZE){
-            throw new BadRequestHandler(ErrorStatus.INVALID_NICKNAME);
+        String profileUrl;
+
+        if(profileImg != null){
+            if(profileImg.getSize() > MAX_UPLOAD_SIZE){
+                throw new BadRequestHandler(ErrorStatus.INVALID_NICKNAME);
+            }
+            profileUrl = s3Manager.uploadFile(profileImg, "profile-images");
+
         } else {
-            String profileUrl = s3Manager.uploadFile(profileImg, "profile-images");
-            user.setProfileImg(profileUrl);
+            profileUrl = user.getProfileImg();
         }
 
+        user.setProfileImg(profileUrl);
         user.setName(profileUpdateDto.getName());
         userRepository.save(user);
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -45,6 +45,7 @@ public class UserService {
     public UserResponseDTO.ProfileUpdateDto updateProfile(UserRequestDTO.ProfileUpdateDto profileUpdateDto, MultipartFile profileImg) {
         final long MAX_UPLOAD_SIZE = 5 * 1024 * 1024;
 
+        //user, nickname handle
         Long userId = SecurityUtils.getUserId();
 
         boolean isDuplicateName = userRepository.existsByName(profileUpdateDto.getName());
@@ -55,11 +56,15 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
+        // profileImg handle
         String profileUrl;
 
         if(profileImg != null){
             if(profileImg.getSize() > MAX_UPLOAD_SIZE){
-                throw new BadRequestHandler(ErrorStatus.INVALID_NICKNAME);
+                throw new BadRequestHandler(ErrorStatus.PAYLOAD_TOO_LARGE);
+            }
+            if(user.getProfileImg() != null){
+                s3Manager.deleteFile(user.getProfileImg());
             }
             profileUrl = s3Manager.uploadFile(profileImg, "profile-images");
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import chungbazi.chungbazi_be.domain.user.repository.*;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
+import chungbazi.chungbazi_be.global.s3.S3Manager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class UserService {
     private final UserAdditionRepository userAdditionRepository;
     private final InterestRepository interestRepository;
     private final UserInterestRepository userInterestRepository;
+    private final S3Manager s3Manager;
 
     public UserResponseDTO.ProfileDto getProfile() {
         Long userId = SecurityUtils.getUserId();
@@ -51,6 +53,8 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
+        String profileUrl = s3Manager.uploadFile(profileImg, "profile-images");
+        user.setProfileImg(profileUrl);
         user.setName(profileUpdateDto.getName());
         userRepository.save(user);
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -39,7 +40,7 @@ public class UserService {
 
         return UserConverter.toProfileDto(user);
     }
-    public UserResponseDTO.ProfileUpdateDto updateProfile(UserRequestDTO.ProfileUpdateDto profileUpdateDto) {
+    public UserResponseDTO.ProfileUpdateDto updateProfile(UserRequestDTO.ProfileUpdateDto profileUpdateDto, MultipartFile profileImg) {
         Long userId = SecurityUtils.getUserId();
 
         boolean isDuplicateName = userRepository.existsByName(profileUpdateDto.getName());

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import chungbazi.chungbazi_be.domain.user.entity.mapping.UserAddition;
 import chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest;
 import chungbazi.chungbazi_be.domain.user.repository.*;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
+import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -38,12 +39,19 @@ public class UserService {
 
         return UserConverter.toProfileDto(user);
     }
-    public UserResponseDTO.ProfileUpdateDto updateProfile(String newName) {
+    public UserResponseDTO.ProfileUpdateDto updateProfile(UserRequestDTO.ProfileUpdateDto profileUpdateDto) {
         Long userId = SecurityUtils.getUserId();
+
+        boolean isDuplicateName = userRepository.existsByName(profileUpdateDto.getName());
+        if(isDuplicateName) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_NICKNAME);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
+        user.setName(profileUpdateDto.getName());
+        userRepository.save(user);
 
         return UserConverter.toProfileUpdateDto(user);
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -38,6 +38,15 @@ public class UserService {
 
         return UserConverter.toProfileDto(user);
     }
+    public UserResponseDTO.ProfileUpdateDto updateProfile(String newName) {
+        Long userId = SecurityUtils.getUserId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+
+
+        return UserConverter.toProfileUpdateDto(user);
+    }
 
     public void registerUserInfo(Long userId, UserRequestDTO.RegisterDto registerDto) {
         User user = userRepository.findById(userId)

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -35,12 +35,17 @@ public enum ErrorStatus implements BaseErrorCode {
     GOOGLE_REQUEST_TOKEN_ERROR(HttpStatus.UNAUTHORIZED,"FCMTOKEN001","firebase 접근 토큰이 유효하지 않습니다."),
     FCM_SEND_FAILURE(HttpStatus.BAD_REQUEST,"FCMSEND001", "FCM 메시지 전송에 실패했습니다."),
   
-      //인증 관련 에러
+    //인증 관련 에러
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4011", "유효하지 않은 access Token 입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN4012", "만료된 토큰입니다."),
     INVALID_OR_EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"TOKEN4014","유효하지 않은 refresh token 입니다."),
     INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, "TOKEN4015", "사용자 ID의 형식이 올바르지 않습니다."),
     INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST,"TOKEN4016","잘못된 인자가 제공되었습니다."),
+
+    //s3 관련 에러
+    NO_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "UPLOAD400", "파일의 이름에 확장자가 존재하지 않습니다."),
+    PICTURE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "PICTURE400", "이미지의 확장자가 잘못되었습니다."),
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "UPLOAD413", "파일 크기가 허용 범위를 초과했습니다."),
     ;
 
 

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -20,9 +20,10 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
     NOT_FOUND_NOTIFICATION(HttpStatus.NOT_FOUND,"NOTIFICATION001","알림이 존재하지 않습니다."),
 
-    // 멤버 관련 에러
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
-    INVALID_GENDER(HttpStatus.BAD_REQUEST, "MEMBER", "유효하지않은 성별입니다."),
+    // User 관련 에러
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
+    INVALID_GENDER(HttpStatus.BAD_REQUEST, "USER400", "유효하지않은 성별입니다."),
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST,"USER400","이미 존재하는 닉네임입니다."),
 
     //Policy
     CATEGORY_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POLICY5001", "존재하지 않는 정책 코드 입니다."),

--- a/src/main/java/chungbazi/chungbazi_be/global/config/S3Confing.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/S3Confing.java
@@ -1,0 +1,30 @@
+package chungbazi.chungbazi_be.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Confing {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3(){
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/config/WebConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package chungbazi.chungbazi_be.global.config;
+
+import chungbazi.chungbazi_be.global.s3.OctetStreamReadMsgConverter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(octetStreamReadMsgConverter);
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/entity/Uuid.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/entity/Uuid.java
@@ -1,0 +1,33 @@
+package chungbazi.chungbazi_be.global.entity;
+
+import chungbazi.chungbazi_be.global.repository.UuidRepository;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Uuid {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String uuid;
+
+    private Uuid(String uuid){
+        this.uuid = uuid;
+    }
+
+    public static Uuid createAndSave(UuidRepository uuidRepository){
+        Uuid uuid = new Uuid(java.util.UUID.randomUUID().toString());
+        return uuidRepository.save(uuid);
+
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/repository/UuidRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/repository/UuidRepository.java
@@ -4,5 +4,6 @@ import chungbazi.chungbazi_be.global.entity.Uuid;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UuidRepository extends JpaRepository<Uuid, Long> {
+    void deleteByUuid(String uuid);
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/repository/UuidRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/repository/UuidRepository.java
@@ -1,0 +1,8 @@
+package chungbazi.chungbazi_be.global.repository;
+
+import chungbazi.chungbazi_be.global.entity.Uuid;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UuidRepository extends JpaRepository<Uuid, Long> {
+
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/s3/OctetStreamReadMsgConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/s3/OctetStreamReadMsgConverter.java
@@ -1,0 +1,29 @@
+package chungbazi.chungbazi_be.global.s3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper){
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType){
+        return false;
+    }
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType){
+        return false;
+    }
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
@@ -80,10 +80,22 @@ public class S3Manager {
             // DeleteObjectRequest를 사용해 파일 삭제
             amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileKey));
             log.info("Successfully deleted file: {}", fileKey);
+
+            // UUID 엔티티 삭제
+            String uuidString = extractUuidFromFileKey(fileKey); // 파일 키에서 UUID 추출
+            uuidRepository.deleteByUuid(uuidString);
+            log.info("Successfully deleted UUID: {}", uuidString);
         } catch (Exception e){
             log.error("Error deleting file from S3: {}", e.getMessage());
             throw new RuntimeException("fail to delete file", e);
         }
+    }
+    private String extractUuidFromFileKey(String fileKey) {
+        int firstUnderscoreIndex = fileKey.indexOf("_");
+        if (firstUnderscoreIndex == -1) {
+            throw new IllegalArgumentException("Invalid file key format. UUID not found.");
+        }
+        return fileKey.substring(fileKey.lastIndexOf("/") + 1, firstUnderscoreIndex);
     }
 
     public void validateImageExtension(String fileName) {

--- a/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
@@ -47,4 +47,18 @@ public class S3Manager {
         return amazonS3.getUrl(bucket, fileName).toString();
     }
 
+    public void deleteFile(String fileName) {
+        if(fileName == null || fileName.isEmpty()){
+            log.warn("fileName is null");
+            return;
+        }
+        try{
+            log.info("Deleting file: {}", fileName);
+            amazonS3.deleteObject(bucket, fileName);
+        } catch (Exception e){
+            log.error("Error deleting file from S3: {}", e.getMessage());
+            throw new RuntimeException("fail to delete file", e);
+        }
+    }
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
@@ -77,6 +77,12 @@ public class S3Manager {
             String fileKey = fileName.substring(bucketUrl.length());
             log.info("Extracted file key: {}", fileKey);
 
+            // 객체 존재 여부 확인
+            if (!amazonS3.doesObjectExist(bucket, fileKey)) {
+                log.warn("File does not exist in S3: {}", fileKey);
+                return; // 파일이 존재하지 않으면 삭제하지 않고 종료
+            }
+
             // DeleteObjectRequest를 사용해 파일 삭제
             amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileKey));
             log.info("Successfully deleted file: {}", fileKey);

--- a/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
@@ -39,8 +39,7 @@ public class S3Manager {
         objectMetadata.setContentType(multipartFile.getContentType());
 
         try(InputStream inputStream = multipartFile.getInputStream()){
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata).withCannedAcl(
-                    CannedAccessControlList.PublicRead));
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata));
         }catch (IOException e){
             log.error("Error uploading file to S3: {}", e.getMessage());
             throw new RuntimeException("파일 업로드에 실패했습니다.", e);

--- a/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/s3/S3Manager.java
@@ -1,0 +1,51 @@
+package chungbazi.chungbazi_be.global.s3;
+
+import chungbazi.chungbazi_be.global.config.S3Confing;
+import chungbazi.chungbazi_be.global.entity.Uuid;
+import chungbazi.chungbazi_be.global.repository.UuidRepository;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Manager {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+    private final UuidRepository uuidRepository;
+
+    public String uploadFile(MultipartFile multipartFile, String dirName){
+        Uuid savedUuid = Uuid.createAndSave(uuidRepository);
+
+        String originalFileName = multipartFile.getOriginalFilename();
+        String uniqueFileName = savedUuid.getUuid() + "_" + (originalFileName != null ? originalFileName.replaceAll("\\s","_") : "unknown");
+        String fileName = dirName + "/" + uniqueFileName;
+
+        log.info("Uploading file: {}", fileName);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try(InputStream inputStream = multipartFile.getInputStream()){
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata).withCannedAcl(
+                    CannedAccessControlList.PublicRead));
+        }catch (IOException e){
+            log.error("Error uploading file to S3: {}", e.getMessage());
+            throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+        }
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
           time_zone: Asia/Seoul
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
           time_zone: Asia/Seoul
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
 
 server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,14 @@ spring:
           time_zone: Asia/Seoul
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 20MB
 
 server:
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
           time_zone: Asia/Seoul
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
 
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
           time_zone: Asia/Seoul
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,15 @@ webclient:
 
 jwt:
   secret-key: ${JWT_KEY}
+
+cloud:
+  aws:
+    s3:
+      bucket: chungbazi
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
## 연관 이슈

close #39 

<br/>

## 개요

마이페이지 유저 정보 수정

<br/>

## ✅ 작업 내용

- [x] 유저 닉네임 수정
- [x] 유저 프로필 수정
- [x] 스웨거 확인
- 닉네임 중복 확인
<img width="283" alt="image" src="https://github.com/user-attachments/assets/37dfb9d9-7263-4cd3-8c51-67833a0463b0" />

- 닉네임 글자수 10자 제한

<img width="286" alt="image" src="https://github.com/user-attachments/assets/8cffc9c2-5158-4077-b148-e496d298cb25" />

- 유저 조회시 이미지 반환(/user/profile)
<img width="857" alt="image" src="https://github.com/user-attachments/assets/703e850b-7bdb-4a09-b101-239ba68412ed" />

- 유저 이미지 수정(/user/profile/update)
<img width="798" alt="image" src="https://github.com/user-attachments/assets/9fcf36ce-dcf1-4f46-8f91-ee36af89a83d" />

- 유저 이미지 수정 -> 확장자 처리
<img width="378" alt="image" src="https://github.com/user-attachments/assets/70fc51c4-1165-48b4-be1e-ea79173188d1" />


- 유저 이미지 수정 -> 이후 재 조회 확인(/user/profile)
<img width="803" alt="image" src="https://github.com/user-attachments/assets/c0fec769-8567-42be-b7f8-adc73f168dcc" />

- 유저 이미지 수정 -> s3 삭제, 변경 확인

<img width="354" alt="image" src="https://github.com/user-attachments/assets/c11d1f94-fa49-4d69-8f5c-8ed8138542c1" />

- 유저 이미지 수정 -> uuid 삭제, 변경 확인

<img width="487" alt="image" src="https://github.com/user-attachments/assets/1b7dd823-772d-4235-8c36-c6eb09d4429e" />




<br/>

### 📝 논의사항

<img width="221" alt="image" src="https://github.com/user-attachments/assets/eb7233e5-c28f-4bd1-9ca5-20bedaee008c" />

@hhongyeahh 로그인시 이렇게 name은 상이한데, email이 동일한 경우 로그인 처리가 되고 있어요!
지금 user에 name과 nickname을 같이 사용하고 있어서 그런 것 같은데.. 우선 닉네임 따로 만들지 않고 네임 == 닉네임으로 보고 유저 정보 수정시 네임 바뀌도록 했습니다ㅜㅜ!

로그인시 이메일 핸들링만 해줄거면 상관없을 것 같긴 한데.. 이대로 할지 의논해보면 좋을 것 같아요!
아니면 닉네임 필드를 추가해서 수정해야 할 것 같습니당


우선 단일 파일 업로드 로직만 구현했고, 추후 여러 장 업로드하면 따로 함수 구현해야 합니다!
`profileUrl = s3Manager.uploadFile(profileImg, "profile-images");` 이런 식으로 두번째 파라미터에 해당 디렉토리 사용하면 좋을 것 같아요!

