### PR TITLE
[feature] 알림 수신 설정 확인 로직 & 알림 조회관련 프론트 요구사항 추가

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -127,7 +127,9 @@ public class CommunityService {
 
         commentRepository.save(comment);
 
-        sendCommunityNotification(post.getId());
+        if(user.getNotificationSetting().isCommunityAlarm()){
+            sendCommunityNotification(post.getId());
+        }
         rewardService.checkRewards();
 
         return CommunityConverter.toUploadAndGetCommentDto(comment);

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
@@ -45,7 +45,10 @@ public class RewardService {
 
                 if (postCount >= requiredCount && commentCount >= requiredCount) {
                     user.updateRewardLevel(nextRewardLevel);
-                    sendRewardNotification(nextRewardLevel.getLevel());
+
+                    if (user.getNotificationSetting().isRewardAlarm()){
+                        sendRewardNotification(nextRewardLevel.getLevel());
+                    }
                 }
             }
         }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
@@ -13,6 +13,7 @@ public class NotificationConverter {
                 .isRead(notification.isRead())
                 .message(notification.getMessage())
                 .type(notification.getType())
+                .formattedCreatedAt(notification.getFormattedCreatedAt())
                 .build();
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
@@ -30,6 +30,7 @@ public class NotificationResponseDTO {
         private boolean isRead;
         private String message;
         private NotificationType type;
+        private String formattedCreatedAt;
     }
 
     @Getter

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package chungbazi.chungbazi_be.domain.notification.entity;
 
+import chungbazi.chungbazi_be.domain.community.utils.TimeFormatter;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
@@ -39,6 +40,10 @@ public class Notification extends BaseTimeEntity {
     // Notification 엔티티 내부
     public void markAsRead() {
         this.isRead = true;
+    }
+
+    public String getFormattedCreatedAt(){
+        return TimeFormatter.formatCreatedAt(this.getCreatedAt());
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
@@ -49,10 +49,10 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom{
         booleanBuilder.and(qNotification.user.id.eq(userId));
 
         //타입필터
-        if(type!=null){
+        if(type!=null && !type.name().isEmpty()){
             booleanBuilder.and(qNotification.type.eq(type));
         }
-        if(cursor!=null){
+        if(cursor!=null && cursor!=0){
             booleanBuilder.and(qNotification.id.lt(cursor));
         }
 


### PR DESCRIPTION
## 연관 이슈

close #53

<br/>

## 개요

알림 생성 시 사용자가 알림 수신 설정을 했는지 확인하고 나서 알림을 생성하는 로직을 추가하였습니다.

그리고 프론트 연결 시 type이 빈 문자열이고, cursor값이 0일 때도 알림 전체 조회가 가능하게 해달라고 해서 추가했습니당

또, 알림 조회 시 몇분 전 알림인지 보내달라해서 전에 예지님이 작성해주신 TimeFormatter 로직을 사용하여 구현해뒀습니다.

<br/>

## ✅ 작업 내용

- [x] 알림 생성 시 사용자 알림 수신 설정 확인하는 로직
- [x] 프론트 api 연결하기 쉽게 알림 조회 검증 수정
- [x] 알림 조회 시 시간 포맷팅 필드 추가 
<img width="618" alt="image" src="https://github.com/user-attachments/assets/7dc44140-0973-4bff-86d7-75df6aaafb0a" />


<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
