### PR TITLE
[feature] 정책(캘린더) 알림 생성 로직

### DIFF
--- a/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QPost.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QPost.java
@@ -39,6 +39,8 @@ public class QPost extends EntityPathBase<Post> {
 
     public final ListPath<String, StringPath> imageUrls = this.<String, StringPath>createList("imageUrls", String.class, StringPath.class, PathInits.DIRECT2);
 
+    public final ListPath<chungbazi.chungbazi_be.domain.notification.entity.Notification, chungbazi.chungbazi_be.domain.notification.entity.QNotification> notifications = this.<chungbazi.chungbazi_be.domain.notification.entity.Notification, chungbazi.chungbazi_be.domain.notification.entity.QNotification>createList("notifications", chungbazi.chungbazi_be.domain.notification.entity.Notification.class, chungbazi.chungbazi_be.domain.notification.entity.QNotification.class, PathInits.DIRECT2);
+
     public final NumberPath<Integer> postLikes = createNumber("postLikes", Integer.class);
 
     public final StringPath title = createString("title");

--- a/src/main/generated/chungbazi/chungbazi_be/domain/notification/entity/QNotification.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/notification/entity/QNotification.java
@@ -33,6 +33,10 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public final StringPath message = createString("message");
 
+    public final chungbazi.chungbazi_be.domain.policy.entity.QPolicy policy;
+
+    public final chungbazi.chungbazi_be.domain.community.entity.QPost post;
+
     public final EnumPath<chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType> type = createEnum("type", chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType.class);
 
     //inherited
@@ -58,6 +62,8 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.policy = inits.isInitialized("policy") ? new chungbazi.chungbazi_be.domain.policy.entity.QPolicy(forProperty("policy")) : null;
+        this.post = inits.isInitialized("post") ? new chungbazi.chungbazi_be.domain.community.entity.QPost(forProperty("post"), inits.get("post")) : null;
         this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
     }
 

--- a/src/main/generated/chungbazi/chungbazi_be/domain/policy/entity/QPolicy.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/policy/entity/QPolicy.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -53,6 +54,8 @@ public class QPolicy extends EntityPathBase<Policy> {
     public final StringPath minIncome = createString("minIncome");
 
     public final StringPath name = createString("name");
+
+    public final ListPath<chungbazi.chungbazi_be.domain.notification.entity.Notification, chungbazi.chungbazi_be.domain.notification.entity.QNotification> notifications = this.<chungbazi.chungbazi_be.domain.notification.entity.Notification, chungbazi.chungbazi_be.domain.notification.entity.QNotification>createList("notifications", chungbazi.chungbazi_be.domain.notification.entity.Notification.class, chungbazi.chungbazi_be.domain.notification.entity.QNotification.class, PathInits.DIRECT2);
 
     public final StringPath posterUrl = createString("posterUrl");
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/KakaoAuthService.java
@@ -59,6 +59,7 @@ public class KakaoAuthService {
         tokenAuthService.addToBlackList(token, "delete-account", 3600L);
         tokenAuthService.deleteRefreshToken(userId);
         userAuthService.deleteUser(userId);
+        fcmTokenService.deleteToken(Long.valueOf(userId));
     }
 
     // 응답

--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
@@ -53,7 +53,10 @@ public class CartService {
 
         Cart cart = new Cart(policy, user);
         cartRepository.save(cart);
-        sendPolicyNotification(policy);
+
+        if(user.getNotificationSetting().isPolicyAlarm()) {
+            sendPolicyNotification(policy);
+        }
 
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Post.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Post.java
@@ -1,6 +1,7 @@
 package chungbazi.chungbazi_be.domain.community.entity;
 
 import chungbazi.chungbazi_be.domain.community.utils.TimeFormatter;
+import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
@@ -65,6 +66,9 @@ public class Post extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL,orphanRemoval = true)
+    private List<Notification> notifications=new ArrayList<>();
 
     public String getThumbnailUrl() {
         return (imageUrls != null && !imageUrls.isEmpty()) ? imageUrls.get(0) : null;

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -131,7 +131,7 @@ public class CommunityService {
 
         commentRepository.save(comment);
 
-        if(user.getNotificationSetting().isCommunityAlarm()){
+        if(user.getNotificationSetting().isCommunityAlarm() && !user.getId().equals(post.getAuthor().getId())){
             sendCommunityNotification(post.getId());
         }
         rewardService.checkRewards();

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -170,19 +170,8 @@ public class CommunityService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_POST));
 
         User author=post.getAuthor();
+        String message=user.getName()+"님이 회원님의 게시글에 댓글을 달았습니다.";
 
-        Notification notification=Notification.builder()
-                .user(author)
-                .type(NotificationType.COMMUNITY_ALARM)
-                .message(user.getName()+"님이 회원님의 게시글에 댓글을 달았습니다.")
-                .isRead(false)
-                .build();
-
-        notificationRepository.save(notification);
-
-        String fcmToken=fcmTokenService.getToken(author.getId());
-        if (fcmToken != null) {
-            notificationService.pushFCMNotification(fcmToken,notification.getType(),notification.getMessage());
-        }
+        notificationService.sendNotification(author, NotificationType.COMMUNITY_ALARM, message, post, null);
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
@@ -36,8 +36,7 @@ public class RewardService {
     private final UserHelper userHelper;
 
     public void checkRewards() {
-        User user = userRepository.findById(SecurityUtils.getUserId())
-                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+        User user = userHelper.getAuthenticatedUser();
 
         int currentReward = user.getReward().getLevel();
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
@@ -13,6 +13,7 @@ import chungbazi.chungbazi_be.domain.notification.service.NotificationService;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.entity.enums.RewardLevel;
 import chungbazi.chungbazi_be.domain.user.repository.UserRepository;
+import chungbazi.chungbazi_be.domain.user.utils.UserHelper;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
 import jakarta.transaction.Transactional;
@@ -32,6 +33,7 @@ public class RewardService {
     private final NotificationService notificationService;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final UserHelper userHelper;
 
     public void checkRewards() {
         User user = userRepository.findById(SecurityUtils.getUserId())
@@ -59,23 +61,10 @@ public class RewardService {
     }
 
     private void sendRewardNotification(int rewardLevel) {
-        User user=userRepository.findById(SecurityUtils.getUserId())
-                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+        User user=userHelper.getAuthenticatedUser();
+        String message = rewardLevel + "단계에 달성하여 캐릭터가 지급되었습니다.";
 
-        Notification notification=Notification.builder()
-                .user(user)
-                .type(NotificationType.REWARD_ALARM)
-                .message(rewardLevel+"단계에 달성하여 캐릭터가 지급되었습니다.")
-                .isRead(false)
-                .build();
-
-        notificationRepository.save(notification);
-
-        //FCM푸시 전송
-        String fcmToken = fcmTokenService.getToken(user.getId());
-        if(fcmToken!=null){
-            notificationService.pushFCMNotification(fcmToken,notification.getType(),notification.getMessage());
-        }
+        notificationService.sendNotification(user, NotificationType.REWARD_ALARM, message, null, null);
     }
 
     public NextLevelInfo calNextLevelInfo(User user, Character character){

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -18,13 +18,6 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
     private final NotificationService notificationService;
 
-    @PostMapping("/create")
-    @Operation(summary = "알림 생성 API", description = "알림을 생성하고, fcm으로 알림을 요청하는 API입니다.")
-    public ApiResponse<NotificationResponseDTO.responseDto> createNotification(@RequestBody NotificationRequestDTO.createDTO dto) {
-        NotificationResponseDTO.responseDto responseDto = notificationService.sendNotification(dto);
-        return ApiResponse.onSuccess(responseDto);
-    }
-
     @PatchMapping("/{notificationId}/read")
     @Operation(summary = "특정 알림 읽음 상태 변경 API")
     public ApiResponse<Void> readNotification(@PathVariable Long notificationId) {

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
@@ -13,6 +13,8 @@ public class NotificationConverter {
                 .isRead(notification.isRead())
                 .message(notification.getMessage())
                 .type(notification.getType())
+                .policyId(notification.getPolicy().getId())
+                .postId(notification.getPost().getId())
                 .formattedCreatedAt(notification.getFormattedCreatedAt())
                 .build();
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/NotificationResponseDTO.java
@@ -30,6 +30,8 @@ public class NotificationResponseDTO {
         private boolean isRead;
         private String message;
         private NotificationType type;
+        private Long policyId;
+        private Long postId;
         private String formattedCreatedAt;
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
@@ -1,7 +1,9 @@
 package chungbazi.chungbazi_be.domain.notification.entity;
 
+import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.community.utils.TimeFormatter;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
+import chungbazi.chungbazi_be.domain.policy.entity.Policy;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
 import com.google.firebase.database.annotations.NotNull;
@@ -33,11 +35,17 @@ public class Notification extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    //댓글이랑 연관관계
+    // 커뮤니티 알림인 경우 (선택적)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
 
-    //장바구니랑 연관관계
+    // 정책 알림인 경우 (선택적)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id")
+    private Policy policy;
 
-    // Notification 엔티티 내부
+
     public void markAsRead() {
         this.isRead = true;
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FCMTokenService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FCMTokenService.java
@@ -21,6 +21,10 @@ public class FCMTokenService {
         return redisTemplate.opsForValue().get("_"+String.valueOf(userId));
     }
 
+    public void deleteToken(Long userId){
+        redisTemplate.delete(String.valueOf("_"+userId));
+    }
+
 
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
@@ -1,16 +1,14 @@
 package chungbazi.chungbazi_be.domain.policy.entity;
 
+import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.policy.dto.YouthPolicyResponse;
 import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -125,6 +123,8 @@ public class Policy extends BaseTimeEntity {
     // 포스터 사진 url
     private String posterUrl;
 
+    @OneToMany(mappedBy = "policy", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Notification> notifications = new ArrayList<>();
 
     public static Policy toEntity(YouthPolicyResponse dto) {
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
@@ -124,7 +124,9 @@ public class User {
     public void postPersistInitialization() {
         // 알람 초기화
         if (this.notificationSetting == null) {
-            this.notificationSetting = new NotificationSetting(this);
+            this.notificationSetting = NotificationSetting.builder()
+                    .user(this)
+                    .build();
         }
         // 캐릭터 리스트 초기화
         if (characters == null || characters.isEmpty()) {

--- a/src/main/java/chungbazi/chungbazi_be/global/config/FirebaseConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/FirebaseConfig.java
@@ -6,22 +6,28 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 import java.io.FileInputStream;
+import java.io.InputStream;
 
 @Configuration
 public class FirebaseConfig {
 
     @PostConstruct
     public void init(){
-        try{
-            FileInputStream serviceAccount=
-                    new FileInputStream("src/main/resources/serviceAccountKey.json");
+        try {
+            ClassPathResource resource = new ClassPathResource("serviceAccountKey.json");
+            InputStream serviceAccount = resource.getInputStream();
+
             FirebaseOptions options = new FirebaseOptions.Builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();
-            FirebaseApp.initializeApp(options);
-        }catch (Exception e){
+
+            if (FirebaseApp.getApps().isEmpty()) { // 기존에 FirebaseApp이 초기화되지 않은 경우만 실행
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/chungbazi/chungbazi_be/global/config/SchedulerConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/SchedulerConfig.java
@@ -1,0 +1,17 @@
+package chungbazi.chungbazi_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler(){
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("scheduler-");
+        return scheduler;
+    }
+}


### PR DESCRIPTION
## 연관 이슈

close #67 

<br/>

## 개요

캘린더 알림 생성 로직 추가하면서, 알림 생성 로직을 하나로 합쳤습니다.
추가로 프론트 요구에 맞게 dto 수정, Notification에 post, policy관련해서 연관관계 추가했습니다!
그리고 @oyatplum User에 postpersist초기화 로직 작성하시면서 notificationSetting이 false로 초기화 되더라구요! 거기 true로 초기화되게 조금 수정했습니다! 참고해주세용

++) @oyatplum 혹시 배포 환경에서도 serviceAccountKey 파일 바꿔주셨을까요?? 바꾸셨다면 배포 환경에서 firebase 설정 초기화 한번만 부탁드립니다!
`FirebaseApp.getApps().clear();` 이걸로 하면 될 거 같아요

<br/>

## ✅ 작업 내용

- [x] 캘린더 알림 생성 로직
- [x] 알림 생성 로직 통일
- [x] notification 연관관계 수정
- [x] 알림 생성 dto 수정

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
