### PR TITLE
[feature] 게시글 좋아요, 취소 API 구현

### DIFF
--- a/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QHeart.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QHeart.java
@@ -1,0 +1,54 @@
+package chungbazi.chungbazi_be.domain.community.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QHeart is a Querydsl query type for Heart
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QHeart extends EntityPathBase<Heart> {
+
+    private static final long serialVersionUID = 1600537246L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QHeart heart = new QHeart("heart");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QPost post;
+
+    public final chungbazi.chungbazi_be.domain.user.entity.QUser user;
+
+    public QHeart(String variable) {
+        this(Heart.class, forVariable(variable), INITS);
+    }
+
+    public QHeart(Path<? extends Heart> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QHeart(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QHeart(PathMetadata metadata, PathInits inits) {
+        this(Heart.class, metadata, inits);
+    }
+
+    public QHeart(Class<? extends Heart> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
+        this.user = inits.isInitialized("user") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
@@ -93,7 +93,7 @@ public class CommunityController {
         return ApiResponse.onSuccess(null);
     }
     @DeleteMapping(value = "/likes")
-    @Operation(summary = "개별 게시글 좋아요 API", description = "개별 게시글 좋아요 API")
+    @Operation(summary = "개별 게시글 좋아요 취소 API", description = "개별 게시글 좋아요 취소 API")
     public ApiResponse<Void> unlikePost(@RequestParam Long postId){
         communityService.unlikePost(postId);
         return ApiResponse.onSuccess(null);

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -84,5 +85,17 @@ public class CommunityController {
             @RequestParam(defaultValue = "10") String size){
         int paseSize = Integer.parseInt(size);
         return ApiResponse.onSuccess(communityService.getComments(postId, cursor, paseSize));
+    }
+    @PostMapping(value = "/likes")
+    @Operation(summary = "개별 게시글 좋아요 API", description = "개별 게시글 좋아요 API")
+    public ApiResponse<Void> likePost(@RequestParam Long postId){
+        communityService.likePost(postId);
+        return ApiResponse.onSuccess(null);
+    }
+    @DeleteMapping(value = "/likes")
+    @Operation(summary = "개별 게시글 좋아요 API", description = "개별 게시글 좋아요 API")
+    public ApiResponse<Void> unlikePost(@RequestParam Long postId){
+        communityService.unlikePost(postId);
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
@@ -47,6 +47,7 @@ public class CommunityConverter {
                 .category(post.getCategory())
                 .formattedCreatedAt(post.getFormattedCreatedAt())
                 .views(post.getViews())
+                .postLikes(post.getPostLikes())
                 .commentCount(commentCount)
                 .userId(post.getAuthor().getId())
                 .userName(post.getAuthor().getName())

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Heart.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Heart.java
@@ -1,0 +1,36 @@
+package chungbazi.chungbazi_be.domain.community.entity;
+
+import chungbazi.chungbazi_be.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@Table(name = "heart")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Heart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Post.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Post.java
@@ -79,4 +79,11 @@ public class Post extends BaseTimeEntity {
     public void incrementViews() {
         this.views = this.views + 1;
     }
+
+    public void incrementLike(){this.postLikes = this.postLikes + 1;}
+    public void decrementLike(){
+        if(this.postLikes > 0) {
+            this.postLikes -= 1;
+        }
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/repository/HeartRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/repository/HeartRepository.java
@@ -1,0 +1,12 @@
+package chungbazi.chungbazi_be.domain.community.repository;
+
+import chungbazi.chungbazi_be.domain.community.entity.Heart;
+import chungbazi.chungbazi_be.domain.community.entity.Post;
+import chungbazi.chungbazi_be.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HeartRepository extends JpaRepository<Heart, Long> {
+    boolean existsByUserAndPost(User user, Post post);
+    Optional<Heart> findByUserAndPost(User user, Post post);
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/repository/HeartRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/repository/HeartRepository.java
@@ -5,8 +5,12 @@ import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
     boolean existsByUserAndPost(User user, Post post);
     Optional<Heart> findByUserAndPost(User user, Post post);
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.post.id = :postId")
+    Long countByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -94,6 +94,7 @@ public class CommunityService {
                 .category(uploadPostDto.getCategory())
                 .author(user)
                 .views(0)
+                .postLikes(0)
                 .imageUrls(uploadedUrls)
                 .build();
         postRepository.save(post);
@@ -179,6 +180,9 @@ public class CommunityService {
 
         Heart heart = Heart.builder().user(user).post(post).build();
         heartRepository.save(heart);
+
+        post.incrementLike();
+        postRepository.save(post);
     }
     public void unlikePost(Long postId){
         User user = userHelper.getAuthenticatedUser();
@@ -188,6 +192,9 @@ public class CommunityService {
         Heart heart = heartRepository.findByUserAndPost(user,post)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_LIKE));
         heartRepository.delete(heart);
+
+        post.decrementLike();
+        postRepository.save(post);
     }
 
     public void sendCommunityNotification(Long postId){

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -5,14 +5,17 @@ import chungbazi.chungbazi_be.domain.community.converter.CommunityConverter;
 import chungbazi.chungbazi_be.domain.community.dto.CommunityRequestDTO;
 import chungbazi.chungbazi_be.domain.community.dto.CommunityResponseDTO;
 import chungbazi.chungbazi_be.domain.community.entity.Comment;
+import chungbazi.chungbazi_be.domain.community.entity.Heart;
 import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.community.repository.CommentRepository;
+import chungbazi.chungbazi_be.domain.community.repository.HeartRepository;
 import chungbazi.chungbazi_be.domain.community.repository.PostRepository;
 import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 import chungbazi.chungbazi_be.domain.notification.repository.NotificationRepository;
 import chungbazi.chungbazi_be.domain.notification.service.FCMTokenService;
 import chungbazi.chungbazi_be.domain.notification.service.NotificationService;
+import chungbazi.chungbazi_be.domain.policy.dto.PolicyDetailsResponse;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.repository.UserRepository;
@@ -43,6 +46,7 @@ public class CommunityService {
     private final FCMTokenService fcmTokenService;
     private final NotificationService notificationService;
     private final UserHelper userHelper;
+    private final HeartRepository heartRepository;
 
     public CommunityResponseDTO.TotalPostListDto getPosts(Category category, Long cursor, int size) {
         Pageable pageable = PageRequest.of(0, size + 1);
@@ -161,6 +165,29 @@ public class CommunityService {
         List<CommunityResponseDTO.UploadAndGetCommentDto> commentsList = CommunityConverter.toListCommentDto(comments);
 
         return CommunityConverter.toGetCommentsListDto(commentsList, nextCursor, hasNext);
+    }
+
+    public void likePost(Long postId){
+        User user = userHelper.getAuthenticatedUser();
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_POST));
+
+        //이미 좋아요한 경우
+        if(heartRepository.existsByUserAndPost(user, post)) {
+            throw new BadRequestHandler(ErrorStatus.ALREADY_LIKED);
+        }
+
+        Heart heart = Heart.builder().user(user).post(post).build();
+        heartRepository.save(heart);
+    }
+    public void unlikePost(Long postId){
+        User user = userHelper.getAuthenticatedUser();
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_POST));
+
+        Heart heart = heartRepository.findByUserAndPost(user,post)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_LIKE));
+        heartRepository.delete(heart);
     }
 
     public void sendCommunityNotification(Long postId){

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_CHARACTER(HttpStatus.NOT_FOUND, "CHARACTER404", "해당 케릭터를 찾을 수 없습니다."),
     NOT_FOUND_DOCUMENT(HttpStatus.NOT_FOUND, "DOCUMENT401", "해당 문서를 찾을 수 없습니다."),
     NOT_FOUND_CART(HttpStatus.NOT_FOUND, "CART401", "해당 장바구니를 찾을 수 없습니다."),
+    NOT_FOUND_LIKE(HttpStatus.NOT_FOUND, "LIKE404", "해당 좋아요를 찾을 수 없습니다."),
 
     // User 관련 에러
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
@@ -66,6 +67,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //community 관련 에러
     FILE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "UPLOAD400", "파일은 10장을 초과할 수 없습니다."),
+    ALREADY_LIKED(HttpStatus.BAD_REQUEST, "LIKE400", "이미 좋아요를 했습니다.")
     ;
 
 


### PR DESCRIPTION
## 연관 이슈

#60 

<br/>

## 개요

게시글 좋아요, 취소 API 구현

<br/>

## ✅ 작업 내용

- [x] 게시글 좋아요, 취소 API 구현

크게 복잡한 사항은 없어서.. 검색 api와 함께 pr 업로드하려고 했는데, 내일 회의에서 검색 로직과 관련하여 논의 사항이 생겨 우선 좋아요 기능만 pr 올렸습니다!
그냥 post 엔티티의 필드 값으로 단순하게 구현할까 생각하기도 했는데, 추후에 유저 좋아요 목록을 이용해 마이페이지에서 이용을 한다던지.. 확장성이 있을 것 같아 heart 엔티티를 생성하고 진행했습니다!
좋아요와 취소 기능도 함께 묶기보다 분리하는게 좋다고 하여 그렇게 진행해보았습니다!!

+) 이미 좋아요했는데, 또 좋아요 하는 경우 / 이미 취소했는데, 또 취소하는 경우도 처리했습니다 :)

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
