### PR TITLE
[feature] 커뮤니티 검색, 인기 검색어 조회 api 구현 및 페이징, 인기 검색어 조회 전역 관리

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
@@ -3,8 +3,10 @@ package chungbazi.chungbazi_be.domain.community.controller;
 import chungbazi.chungbazi_be.domain.community.dto.CommunityRequestDTO;
 import chungbazi.chungbazi_be.domain.community.dto.CommunityResponseDTO;
 import chungbazi.chungbazi_be.domain.community.service.CommunityService;
+import chungbazi.chungbazi_be.domain.policy.dto.PopularSearchResponse;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
+import chungbazi.chungbazi_be.global.service.PopularSearchService;
 import com.google.protobuf.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -26,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/community")
 public class CommunityController {
     private final CommunityService communityService;
+    private final PopularSearchService popularSearchService;
 
     @PostMapping(value = "/posts/upload", consumes = "multipart/form-data")
     @Operation(summary = "게시글 업로드 API",
@@ -108,6 +111,12 @@ public class CommunityController {
             @RequestParam(defaultValue = "10") int size
     ) {
         CommunityResponseDTO.TotalPostListDto response = communityService.getSearchPost(query, filter, period, cursor, size);
+        return ApiResponse.onSuccess(response);
+    }
+    @GetMapping("/search/popular")
+    @Operation(summary = "커뮤니티 인기 검색어 조회 API", description = "커뮤니티 인기 검색어 조회 API")
+    public ApiResponse<PopularSearchResponse> getSearchPopular(){
+        PopularSearchResponse response = popularSearchService.getPopularSearch("community");
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
@@ -98,4 +98,16 @@ public class CommunityController {
         communityService.unlikePost(postId);
         return ApiResponse.onSuccess(null);
     }
+    @GetMapping("/search")
+    @Operation(summary = "커뮤니티 검색 API", description = "커뮤니티 검색 API")
+    public ApiResponse<CommunityResponseDTO.TotalPostListDto> getSearchPost(
+            @RequestParam String query,
+            @RequestParam(value = "filter", required = false, defaultValue = "title") String filter,
+            @RequestParam(value = "period", required = false, defaultValue = "all") String period,
+            @RequestParam Long cursor,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        CommunityResponseDTO.TotalPostListDto response = communityService.getSearchPost(query, filter, period, cursor, size);
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/controller/CommunityController.java
@@ -61,9 +61,8 @@ public class CommunityController {
     public ApiResponse<CommunityResponseDTO.TotalPostListDto> getPosts(
             @RequestParam(required = false) Category category,
             @RequestParam Long cursor,
-            @RequestParam(defaultValue = "10") String size){
-        int paseSize = Integer.parseInt(size);
-        return ApiResponse.onSuccess(communityService.getPosts(category,cursor,paseSize));
+            @RequestParam(defaultValue = "10") int size){
+        return ApiResponse.onSuccess(communityService.getPosts(category, cursor, size));
     }
 
     @GetMapping(value = "/posts/{postId}")
@@ -85,9 +84,8 @@ public class CommunityController {
     public ApiResponse<CommunityResponseDTO.CommentListDto> getComments(
             @RequestParam Long postId,
             @RequestParam Long cursor,
-            @RequestParam(defaultValue = "10") String size){
-        int paseSize = Integer.parseInt(size);
-        return ApiResponse.onSuccess(communityService.getComments(postId, cursor, paseSize));
+            @RequestParam(defaultValue = "10") int size){
+        return ApiResponse.onSuccess(communityService.getComments(postId, cursor, size));
     }
     @PostMapping(value = "/likes")
     @Operation(summary = "개별 게시글 좋아요 API", description = "개별 게시글 좋아요 API")

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Comment.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Comment.java
@@ -1,6 +1,6 @@
 package chungbazi.chungbazi_be.domain.community.entity;
 
-import chungbazi.chungbazi_be.domain.community.utils.TimeFormatter;
+import chungbazi.chungbazi_be.global.utils.TimeFormatter;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Post.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Post.java
@@ -1,6 +1,6 @@
 package chungbazi.chungbazi_be.domain.community.entity;
 
-import chungbazi.chungbazi_be.domain.community.utils.TimeFormatter;
+import chungbazi.chungbazi_be.global.utils.TimeFormatter;
 import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.domain.user.entity.User;

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/repository/PostRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/repository/PostRepository.java
@@ -2,6 +2,7 @@ package chungbazi.chungbazi_be.domain.community.repository;
 
 import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,4 +30,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     //user의 게시글 수
     @Query("SELECT  COUNT(p) FROM Post p WHERE p.author.id= :authorId ")
     int countPostByAuthorId(@Param("authorId") Long authorId);
+    //제목으로 검색
+    Page<Post> findByTitleContainingAndCreatedAtAfterOrderByIdDesc(String title, LocalDateTime startDate, Pageable pageable);
+    Page<Post> findByTitleContainingAndCreatedAtAfterAndIdLessThanOrderByIdDesc(String title, LocalDateTime startDate, Long cursor, Pageable pageable);
+    //내용으로 검색
+    Page<Post> findByContentContainingAndCreatedAtAfterOrderByIdDesc(String title, LocalDateTime startDate, Pageable pageable);
+    Page<Post> findByContentContainingAndCreatedAtAfterAndIdLessThanOrderByIdDesc(String title, LocalDateTime startDate, Long cursor, Pageable pageable);
+
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -27,12 +27,18 @@ import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandle
 import chungbazi.chungbazi_be.global.s3.S3Manager;
 import chungbazi.chungbazi_be.global.utils.PaginationResult;
 import chungbazi.chungbazi_be.global.utils.PaginationUtil;
+import chungbazi.chungbazi_be.global.utils.PopularSearch;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,6 +56,8 @@ public class CommunityService {
     private final NotificationService notificationService;
     private final UserHelper userHelper;
     private final HeartRepository heartRepository;
+    private final PopularSearch popularSearch;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public CommunityResponseDTO.TotalPostListDto getPosts(Category category, Long cursor, int size) {
         Pageable pageable = PageRequest.of(0, size + 1);
@@ -226,7 +234,7 @@ public class CommunityService {
                     : postRepository.findByContentContainingAndCreatedAtAfterAndIdLessThanOrderByIdDesc(query, startDate, cursor, pageable).getContent();
         }
 
-        //updatePopularSearch(query); 인기검색어
+        popularSearch.updatePopularSearch(query, "community");
 
         PaginationResult<Post> paginationResult = PaginationUtil.paginate(posts, size);
         posts = paginationResult.getItems();

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
@@ -1,7 +1,7 @@
 package chungbazi.chungbazi_be.domain.notification.entity;
 
 import chungbazi.chungbazi_be.domain.community.entity.Post;
-import chungbazi.chungbazi_be.domain.community.utils.TimeFormatter;
+import chungbazi.chungbazi_be.global.utils.TimeFormatter;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 import chungbazi.chungbazi_be.domain.policy.entity.Policy;
 import chungbazi.chungbazi_be.domain.user.entity.User;

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/controller/PolicyController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/controller/PolicyController.java
@@ -9,6 +9,7 @@ import chungbazi.chungbazi_be.domain.policy.dto.PopularSearchResponse;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.domain.policy.service.PolicyService;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
+import chungbazi.chungbazi_be.global.service.PopularSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class PolicyController {
 
     private final PolicyService policyService;
     private final CalendarDocumentService calendarDocumentService;
+    private final PopularSearchService popularSearchService;
 
     // 정책 검색
     @Operation(summary = "정책 검색 API", description = "정책 검색")
@@ -43,8 +45,7 @@ public class PolicyController {
     @Operation(summary = "인기 검색어 조회 API", description = "인기 검색어 조회")
     @GetMapping("/search/popular")
     public ApiResponse<PopularSearchResponse> getPopularSearch() {
-
-        PopularSearchResponse response = policyService.getPopularSearch();
+        PopularSearchResponse response = popularSearchService.getPopularSearch("policy");
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -21,6 +21,7 @@ import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.GeneralException;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
+import chungbazi.chungbazi_be.global.utils.PopularSearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.querydsl.core.Tuple;
 import java.time.LocalDate;
@@ -50,6 +51,7 @@ public class PolicyService {
     private final RedisTemplate<String, String> redisTemplate;
     private final CartService cartService;
     private final CalendarDocumentService calendarDocumentService;
+    private final PopularSearch popularSearch;
 
 
     @Value("${webclient.openApiVlak}")
@@ -114,10 +116,8 @@ public class PolicyService {
             throw new GeneralException(ErrorStatus.NO_SEARCH_NAME);
         }
 
-        String normalizedName = normalizeSearchItem(name);
-
         // 인기 검색어에 반영
-        updatePopularSearch(normalizedName);
+        popularSearch.updatePopularSearch(name, "policy");
 
         // 검색 결과 반환
         List<Tuple> policies = policyRepository.searchPolicyWithName(name, cursor, size + 1, order);
@@ -144,21 +144,6 @@ public class PolicyService {
 
         return PolicyListResponse.of(policyDtoList, nextCursor, hasNext);
     }
-
-
-    // 인기 검색어 조회
-    public PopularSearchResponse getPopularSearch() {
-
-        ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();  //Sorted Set을 다루기 위한 인터페이스
-        String key = "ranking:" + LocalDate.now().format(DateTimeFormatter.ISO_DATE);
-
-        //상위 6개 검색어 반환
-        Set<String> result = zSetOperations.reverseRange(key, 0, 5);
-        List<String> resultList = result.stream().toList();
-        return PopularSearchResponse.from(resultList);
-
-    }
-
 
     // 카테고리별 정책 조회
     public PolicyListResponse getCategoryPolicy(Category categoryName, Long cursor, int size, String order) {
@@ -233,52 +218,6 @@ public class PolicyService {
         }
 
         return false;
-    }
-
-
-    // 띄어쓰기, 대소문자 구분 X
-    private String normalizeSearchItem(String searchItem) {
-
-        //소문자 변환
-        String normalized = searchItem.toLowerCase();
-
-        //띄어쓰기 제거
-        normalized = normalized.replaceAll("\\s+", " ");
-
-        return normalized;
-    }
-
-
-    // 인기 검색어에 반영
-    private void updatePopularSearch(String normalizedName) {
-        ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();  //Sorted Set을 다루기 위한 인터페이스
-
-        // 인기 검색어에 반영 (오늘 포함 3일치 key에 저장, 오늘+1/내일+0.6/내일모레+0.3
-        for (int i = 0; i < 3; i++) {
-
-            String key = "ranking:" + LocalDate.now().plusDays(i).format(DateTimeFormatter.ISO_DATE);
-
-            // 키 존재 여부 확인, TTL 설정
-            boolean keyExists = Boolean.TRUE.equals(redisTemplate.hasKey(key));
-            if (!keyExists) {
-                redisTemplate.expire(key, 3, TimeUnit.DAYS);
-            }
-
-            Double cnt = zSetOperations.score(key, normalizedName); // score는 double 타입을 반환
-
-            double num = switch (i) {
-                case 0 -> 1;
-                case 1 -> 0.6;
-                case 2 -> 0.3;
-                default -> 0;
-            };
-
-            if (cnt == null) {
-                zSetOperations.add(key, normalizedName, num);
-            } else {
-                zSetOperations.add(key, normalizedName, cnt + num);
-            }
-        }
     }
 
     public Policy findByPolicyId(Long policyId) {

--- a/src/main/java/chungbazi/chungbazi_be/global/service/PopularSearchService.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/service/PopularSearchService.java
@@ -1,0 +1,29 @@
+package chungbazi.chungbazi_be.global.service;
+
+import chungbazi.chungbazi_be.domain.policy.dto.PopularSearchResponse;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PopularSearchService {
+    private final RedisTemplate<String, String> redisTemplate;
+    public PopularSearchResponse getPopularSearch(String category) {
+
+        ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();  //Sorted Set을 다루기 위한 인터페이스
+        String key = "ranking:" + category + ":" + LocalDate.now().format(DateTimeFormatter.ISO_DATE);
+
+        //상위 6개 검색어 반환
+        Set<String> result = zSetOperations.reverseRange(key, 0, 5);
+        List<String> resultList = result.stream().toList();
+        return PopularSearchResponse.from(resultList);
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/PaginationResult.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/PaginationResult.java
@@ -1,0 +1,15 @@
+package chungbazi.chungbazi_be.global.utils;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PaginationResult<T> {
+    private List<T> items;
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/PaginationUtil.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/PaginationUtil.java
@@ -1,0 +1,27 @@
+package chungbazi.chungbazi_be.global.utils;
+
+import chungbazi.chungbazi_be.domain.community.entity.Comment;
+import chungbazi.chungbazi_be.domain.community.entity.Post;
+import java.util.List;
+
+public class PaginationUtil {
+    public static <T> PaginationResult<T> paginate(List<T> items, int size) {
+        boolean hasNext = items.size() > size;
+        Long nextCursor = 0L;
+
+        if (hasNext) {
+            T lastItem = items.get(size - 1);
+
+            if (lastItem instanceof Post) {
+                nextCursor = ((Post) lastItem).getId();
+            } else if (lastItem instanceof Comment) {
+                nextCursor = ((Comment) lastItem).getId();
+            } else {
+                throw new IllegalArgumentException("Unsupported entity type for pagination");
+            }
+
+            items = items.subList(0, size);
+        }
+        return new  PaginationResult<>(items, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/PopularSearch.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/PopularSearch.java
@@ -1,0 +1,58 @@
+package chungbazi.chungbazi_be.global.utils;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PopularSearch {
+    private final RedisTemplate<String, String> redisTemplate;
+    // 띄어쓰기, 대소문자 구분 X
+    private String normalizeSearchItem(String searchItem) {
+
+        //소문자 변환
+        String normalized = searchItem.toLowerCase();
+
+        //띄어쓰기 제거
+        normalized = normalized.replaceAll("\\s+", " ");
+
+        return normalized;
+    }
+
+    // 인기 검색어에 반영
+    public void updatePopularSearch(String query, String category) {
+        String normalizedQuery = normalizeSearchItem(query);
+        ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();  //Sorted Set을 다루기 위한 인터페이스
+
+        // 인기 검색어에 반영 (오늘 포함 3일치 key에 저장, 오늘+1/내일+0.6/내일모레+0.3
+        for (int i = 0; i < 3; i++) {
+            String key = "ranking:" + category + ":" + LocalDate.now().plusDays(i).format(DateTimeFormatter.ISO_DATE);
+
+            // 키 존재 여부 확인, TTL 설정
+            boolean keyExists = Boolean.TRUE.equals(redisTemplate.hasKey(key));
+            if (!keyExists) {
+                redisTemplate.expire(key, 3, TimeUnit.DAYS);
+            }
+
+            Double cnt = zSetOperations.score(key, normalizedQuery); // score는 double 타입을 반환
+
+            double num = switch (i) {
+                case 0 -> 1;
+                case 1 -> 0.6;
+                case 2 -> 0.3;
+                default -> 0;
+            };
+
+            if (cnt == null) {
+                zSetOperations.add(key, normalizedQuery, num);
+            } else {
+                zSetOperations.add(key, normalizedQuery, cnt + num);
+            }
+        }
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/TimeFormatter.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/TimeFormatter.java
@@ -1,4 +1,4 @@
-package chungbazi.chungbazi_be.domain.community.utils;
+package chungbazi.chungbazi_be.global.utils;
 
 import java.time.Duration;
 import java.time.LocalDateTime;


### PR DESCRIPTION
## 연관 이슈

close #60 

<br/>

## 개요

커뮤니티 검색, 인기 검색어 조회 api 구현 및 페이징, 인기 검색어 조회 전역 관리

<br/>

## ✅ 작업 내용

- [x] 커뮤니티 검색, 인기 검색어 조회 api 구현
- [x] 페이징, 인기 검색어 조회 전역 관리
- [x] 스웨거 테스트 완료

<br/>

### 📝 논의사항

전달 사항은 크게 두 가지입니다!
1. 페이징 전역 관리 @sh0311 @dldusgh318 
현재 페이징 기능을 정책, 커뮤니티, 알림에서 사용하고 있는 것 같아요! 동일한 로직이 세 번 반복되고 있어서 `PaginationUtil` 로 전역 처리했습니다. 동일한 로직이라 함께 사용하면 좋을 것 같은데 저는 `Pageable` 을 사용하고 있거든요!
우선 전역 처리한 로직을 사용하였을 때, 저는 잘 작동되는 것까지 확인했습니다. 혹시 적용하게 되신다면, 스웨거로 작동하는지까지 여부 확인해주셔야할 것 같아요! (보니까 구현하신 로직이 다른 것들이 있는 것 같아서요!)
+) 추가적으로 프론트와 상의했을 때, 디폴트 값으로 null은 최대한 지양해달라고 하셔서 cursor를 0 기준으로 구현했습니다. 이에 전역 처리한 로직에서도 `nextCursor = 0L;` 으로 되어있어요! 사용하시게 된다면, 로직 변경하신 후, 담당 프론트 분께 타입 변경 말씀드려야 합니다!! (전역 처리로 함께 사용하는 것을 저는 선호해요!)

2. 인기 검색어 조회 전역 관리 @sh0311 
구현하셨던 로직 그대로 사용했습니다! 다만, 서비스에서 `normalizeSearchItem` , `updatePopularSearch` 로직이 반복으로 적용되어야 하길래 전역 처리했습니다! 정책 인기 검색어와 커뮤니티 인기 검색어는 구분되어야 해서 `category ` 키 값으로 구분하도록 했어요!
이에 맞추어 정책 로직도 변경하긴 했습니다!
커뮤니티 인기 검색어는 잘 돌아가는 것을 확인했고, 정책 인기 검색어에도 영향이 없는 것까진 확인했는데, 추후 한 번 더 확인해주시면 감사하겠습니다 :)

