### PR TITLE
[refactor] 알림 조회 무한페이징 로직 이용 & dto 수정

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
@@ -58,7 +58,7 @@ public class CartService {
         Cart cart = new Cart(policy, user);
         cartRepository.save(cart);
 
-        if(user.getNotificationSetting().isPolicyAlarm()) {
+        if(user.getNotificationSetting().isPolicyAlarm() &&policy.getEndDate()!=null) {
             sendPolicyNotification(policy);
         }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/converter/NotificationConverter.java
@@ -4,17 +4,32 @@ import chungbazi.chungbazi_be.domain.notification.dto.NotificationResponseDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationSettingResDto;
 import chungbazi.chungbazi_be.domain.notification.entity.Notification;
 import chungbazi.chungbazi_be.domain.notification.entity.NotificationSetting;
+import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
 
 public class NotificationConverter {
 
     public static NotificationResponseDTO.notificationDto toNotificationDto(Notification notification){
+        Long policyId = null;
+        Long postId = null;
+
+        // notification 타입에 따라 관련 ID를 할당해줘 피카~
+        if (notification.getType() == NotificationType.POLICY_ALARM) {
+            if (notification.getPolicy() != null) {
+                policyId = notification.getPolicy().getId();
+            }
+        } else if (notification.getType() == NotificationType.COMMUNITY_ALARM) {
+            if (notification.getPost() != null) {
+                postId = notification.getPost().getId();
+            }
+        }
+
         return NotificationResponseDTO.notificationDto.builder()
                 .notificationId(notification.getId())
                 .isRead(notification.isRead())
                 .message(notification.getMessage())
                 .type(notification.getType())
-                .policyId(notification.getPolicy().getId())
-                .postId(notification.getPost().getId())
+                .policyId(policyId)  // POLICY 타입일 경우에만 값이 들어감 피카~
+                .postId(postId)      // COMMUNITY 타입일 경우에만 값이 들어감 피카~
                 .formattedCreatedAt(notification.getFormattedCreatedAt())
                 .build();
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -53,7 +53,7 @@ public class NotificationService {
         //FCM 푸시 전송
         String fcmToken= fcmTokenService.getToken(user.getId());
         if(fcmToken!=null){
-            pushFCMNotification(fcmToken,type,message);
+            pushFCMNotification(fcmToken,message);
         }
         return NotificationResponseDTO.responseDto.builder()
                 .notificationId(notification.getId())
@@ -62,12 +62,11 @@ public class NotificationService {
     }
 
     //fcm한테 알림 요청
-    public void pushFCMNotification(String fcmToken,NotificationType type,String message) {
+    public void pushFCMNotification(String fcmToken,String message) {
         try {
             com.google.firebase.messaging.Notification notification =
                     com.google.firebase.messaging.Notification.builder()
                             .setTitle("새로운 알림이 도착했습니다.")
-                            .setBody("[" + type.toString() + "]" + message)
                             .build();
 
             Message firebaseMessage = Message.builder()

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -17,6 +17,8 @@ import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.repository.UserRepository;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
+import chungbazi.chungbazi_be.global.utils.PaginationResult;
+import chungbazi.chungbazi_be.global.utils.PaginationUtil;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -101,14 +103,9 @@ public class NotificationService {
 
         List<Notification> notificationList = notificationRepository.findNotificationsByUserIdAndNotificationType(userId, type, cursor, limit + 1);
 
-        Long nextCursor = null;
-        boolean hasNext=notificationList.size() > limit;
+        PaginationResult<Notification> paginationResult = PaginationUtil.paginate(notificationList, limit);
 
-        if (hasNext) {
-            Notification lastNotification = notificationList.get(limit - 1);
-            nextCursor = lastNotification.getId();
-            notificationList = notificationList.subList(0, limit);
-        }
+        notificationList=paginationResult.getItems();
 
         List<NotificationResponseDTO.notificationDto> notificationDtos=notificationList.stream()
                 .map(notification -> NotificationConverter.toNotificationDto(notification))
@@ -116,8 +113,8 @@ public class NotificationService {
 
         return NotificationResponseDTO.notificationListDto.builder()
                 .notifications(notificationDtos)
-                .nextCursor(nextCursor)
-                .hasNext(hasNext)
+                .nextCursor(paginationResult.getNextCursor())
+                .hasNext(paginationResult.isHasNext())
                 .build();
 
     }


### PR DESCRIPTION
## 연관 이슈

close #74 

<br/>

## 개요

알림 조회 시, 무한페이징 로직을 예지님이 전역처리해주셔서 pagingUtil로 리팩토링했습니다.
추가로, fcm으로 알림 전송할 때 타입이 필요없다하셔서 수정했습니다

<br/>

## ✅ 작업 내용

- [x] 무한페이징 리팩토링
- [x] fcm 전송 데이터 수정
<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
