### PR TITLE
[feat] 회원탈퇴 익명화

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/UserAuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/UserAuthService.java
@@ -46,7 +46,7 @@ public class UserAuthService {
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
-
-        userRepository.delete(user);
+        // 유저 익명화 (username & email 무력화)
+        userRepository.anonymizeUser(userId);
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -2,7 +2,11 @@ package chungbazi.chungbazi_be.domain.user.repository;
 
 import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -11,5 +15,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByName(String name);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE User u SET u.name = '알 수 없음', u.email = CONCAT('deleted_', u.id, '@yourdomain.com') WHERE u.id = :userId")
+    void anonymizeUser(@Param("userId") Long userId);
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -18,7 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Modifying
     @Transactional
-    @Query("UPDATE User u SET u.name = '알 수 없음', u.email = CONCAT('deleted_', u.id, '@yourdomain.com') WHERE u.id = :userId")
+    @Query("UPDATE User u SET u.name = '알 수 없음', u.email = CONCAT('deleted_', u.id, '@chungbazi.com') WHERE u.id = :userId")
     void anonymizeUser(@Param("userId") Long userId);
 
 }


### PR DESCRIPTION
## 연관 이슈

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
회원탈퇴 시, 이름과 이메일을 익명화하여, 사용자의 DB가 남을 수 있도록 수정한다.
<img width="763" alt="스크린샷 2025-02-15 오전 4 11 33" src="https://github.com/user-attachments/assets/bfe318ac-479b-4d5b-80d2-70738c63a437" />

이름은 "알 수 없음"
email은 "deleted_userId@chungbazi.com"으로 수정되도록 설정

- 게시글 조회
<img width="763" alt="스크린샷 2025-02-15 오전 4 13 13" src="https://github.com/user-attachments/assets/670135b1-c238-45bb-8058-d0ed63b660ba" />

- 게시글 댓글 조회
<img width="932" alt="스크린샷 2025-02-15 오전 4 13 50" src="https://github.com/user-attachments/assets/8a9b7a01-4d4a-453f-bfbb-84db662876d9" />


<br/>