### PR TITLE
[feature] 안 읽은 알림있는지 확인하는 로직

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -3,7 +3,6 @@ package chungbazi.chungbazi_be.domain.notification.service;
 import chungbazi.chungbazi_be.domain.auth.jwt.SecurityUtils;
 import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.notification.converter.NotificationConverter;
-import chungbazi.chungbazi_be.domain.notification.dto.NotificationRequestDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationResponseDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationSettingReqDto;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationSettingResDto;
@@ -15,6 +14,7 @@ import chungbazi.chungbazi_be.domain.notification.repository.NotificationSetting
 import chungbazi.chungbazi_be.domain.policy.entity.Policy;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.repository.UserRepository;
+import chungbazi.chungbazi_be.domain.user.utils.UserHelper;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
 import chungbazi.chungbazi_be.global.utils.PaginationResult;
@@ -39,6 +39,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final FCMTokenService fcmTokenService;
     private final NotificationSettingRepository notificationSettingRepository;
+    private final UserHelper userHelper;
 
     public NotificationResponseDTO.responseDto sendNotification(User user, NotificationType type, String message, Post post, Policy policy) {
         Notification notification=Notification.builder()
@@ -145,6 +146,14 @@ public class NotificationService {
         NotificationSetting setting=user.getNotificationSetting();
 
         return NotificationConverter.toSettingResDto(setting);
+    }
+
+    //안 읽은 알림이 있는지 검사하는 로직
+    public boolean isReadAllNotification(){
+        User user=userHelper.getAuthenticatedUser();
+
+        return user.getNotificationList().stream()
+                .anyMatch(notification -> !notification.isRead());
     }
 
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/dto/PolicyRecommendResponse.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/dto/PolicyRecommendResponse.java
@@ -13,10 +13,11 @@ public class PolicyRecommendResponse {
 
     private List<PolicyListOneResponse> policies;
     private Set<Category> interests;
+    private boolean isReadAllNotifications;
     private boolean hasNext;
     private Long nextCursor;
 
-    public static PolicyRecommendResponse of(List<Policy> policies, Set<Category> interests, boolean hasNext) {
+    public static PolicyRecommendResponse of(List<Policy> policies, Set<Category> interests, boolean hasNext,boolean isReadAllNotifications) {
         List<PolicyListOneResponse> response = policies.stream()
                 .map(PolicyListOneResponse::from)
                 .toList();
@@ -24,6 +25,6 @@ public class PolicyRecommendResponse {
         Long nextCursor = hasNext ? policies.get(policies.size() - 1).getId() : null;
 
         return PolicyRecommendResponse.builder().policies(response).interests(interests).hasNext(hasNext)
-                .nextCursor(nextCursor).build();
+                .isReadAllNotifications(isReadAllNotifications).nextCursor(nextCursor).build();
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -5,6 +5,7 @@ import chungbazi.chungbazi_be.domain.cart.entity.Cart;
 import chungbazi.chungbazi_be.domain.cart.service.CartService;
 import chungbazi.chungbazi_be.domain.document.entity.CalendarDocument;
 import chungbazi.chungbazi_be.domain.document.service.CalendarDocumentService;
+import chungbazi.chungbazi_be.domain.notification.service.NotificationService;
 import chungbazi.chungbazi_be.domain.policy.dto.PolicyCalendarDetailResponse;
 import chungbazi.chungbazi_be.domain.policy.dto.PolicyCalendarResponse;
 import chungbazi.chungbazi_be.domain.policy.dto.PolicyDetailsResponse;
@@ -57,6 +58,7 @@ public class PolicyService {
     private final CalendarDocumentService calendarDocumentService;
     private final PopularSearch popularSearch;
     private final UserHelper userHelper;
+    private final NotificationService notificationService;
 
 
     @Value("${webclient.openApiVlak}")
@@ -281,7 +283,10 @@ public class PolicyService {
         if (hasNext) {
             filteredPolicies = filteredPolicies.subList(0, size);
         }
-        return PolicyRecommendResponse.of(policies, userCategories, hasNext);
+
+        boolean isReadAllNotifications=notificationService.isReadAllNotification();
+
+        return PolicyRecommendResponse.of(policies, userCategories, hasNext,isReadAllNotifications);
     }
 
 


### PR DESCRIPTION
## 연관 이슈

close #80 

<br/>

## 개요

홈화면, 추천화면에서 안 읽은 알림이 있는지 확인하는 필드가 필요하다해서 추천 정책 조회 api에 추가하였습니다.
안 읽은 알림이 있다면 true를, 없다면 false를 반환하게 로직 설정했습니당

PolicyService에서 구현할까 고민했는데, 이후에 다른 화면에서도 사용될 걸 고려하여 notificationService에 구현했습니당

<img width="698" alt="image" src="https://github.com/user-attachments/assets/b30ae1a0-fa65-43ad-9a53-071612d17547" />


<br/>

## ✅ 작업 내용

- [x] 안 읽은 알림이 있는지 확인하는 로직 구현
- [x] 추천 정책 조회 api에 추가


<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
