### PR TITLE
[fix] 알림 조회 시, 알림 개수가 limit값보다 많을 경우 생기는 에러

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/NotificationRepositoryImpl.java
@@ -61,7 +61,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom{
                 .selectFrom(qNotification)
                 .where(booleanBuilder)
                 .orderBy(qNotification.createdAt.desc())
-                .limit(limit)
+                .limit(limit+1)
                 .fetch();
 
         return notifications;

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -122,9 +122,7 @@ public class NotificationService {
 
         PaginationResult<Notification> paginationResult = PaginationUtil.paginate(notificationList, limit);
 
-        notificationList=paginationResult.getItems();
-
-        List<NotificationResponseDTO.notificationDto> notificationDtos=notificationList.stream()
+        List<NotificationResponseDTO.notificationDto> notificationDtos=paginationResult.getItems().stream()
                 .map(notification -> NotificationConverter.toNotificationDto(notification))
                 .collect(Collectors.toList());
 

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/PaginationUtil.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/PaginationUtil.java
@@ -2,6 +2,8 @@ package chungbazi.chungbazi_be.global.utils;
 
 import chungbazi.chungbazi_be.domain.community.entity.Comment;
 import chungbazi.chungbazi_be.domain.community.entity.Post;
+import chungbazi.chungbazi_be.domain.notification.entity.Notification;
+
 import java.util.List;
 
 public class PaginationUtil {
@@ -16,7 +18,9 @@ public class PaginationUtil {
                 nextCursor = ((Post) lastItem).getId();
             } else if (lastItem instanceof Comment) {
                 nextCursor = ((Comment) lastItem).getId();
-            } else {
+            } else if (lastItem instanceof Notification) { // 🔥 Notification 추가
+                nextCursor = ((Notification) lastItem).getId();
+            }else {
                 throw new IllegalArgumentException("Unsupported entity type for pagination");
             }
 


### PR DESCRIPTION
## 연관 이슈

close #86 

<br/>

## 개요

알림 조회 시, 알림 개수가 limit값보다 많을 경우 생기는 에러가 발생하여 해결하였습니다

PaginationUtil.paginate()에서 엔티티 타입을 검사할 때, Notification 엔티티가 빠져 있어서 오류가 발생했어서 이 부분에 코드 추가하였습니다. 
<br/>

## ✅ 작업 내용

- [x] 알림 조회 시, limit값 에러 해결

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
