### PR TITLE
[feat] 이메일 인증번호 전송 및 검증, 비밀번호 재설정 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,16 @@ dependencyManagement {
     }
 }
 
+
+
+configurations.all {
+    exclude group: 'com.sun.mail', module: 'jakarta.mail'
+    exclude group: 'com.sun.mail', module: 'mailapi'
+    exclude group: 'javax.mail', module: 'mail'
+    exclude group: 'jakarta.mail', module: 'jakarta.mail-api'
+    exclude group: 'javax.activation', module: 'activation'
+}
+
 dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -49,7 +59,11 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
   
 	// Firebase Admin
-	implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation('com.google.firebase:firebase-admin:9.2.0') {
+        exclude group: 'javax.mail'
+        exclude group: 'jakarta.mail'
+        exclude group: 'com.sun.mail'
+    }
   
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -77,7 +91,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-
+    //mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // QueryDsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
-
     private final AuthService authService;
 
     // 일반 사용자 회원가입 API
@@ -72,4 +71,10 @@ public class AuthController {
         authService.deleteUserAccount(token);
         return ApiResponse.onSuccess("Account deletion successful.");
     }
+    @PostMapping("/reset-password")
+    public ApiResponse<String> resetPassword(@RequestBody @Valid TokenRequestDTO.ResetPasswordRequestDTO request) {
+        authService.resetPassword(request.getNewPassword());
+        return ApiResponse.onSuccess("비밀번호가 성공적으로 변경되었습니다.");
+    }
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/MailController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/MailController.java
@@ -1,0 +1,30 @@
+package chungbazi.chungbazi_be.domain.auth.controller;
+
+import chungbazi.chungbazi_be.domain.auth.dto.TokenRequestDTO;
+import chungbazi.chungbazi_be.domain.auth.service.MailService;
+import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/email")
+public class MailController {
+    private final MailService mailService;
+
+    @PostMapping("/verification-requests")
+    @Operation(summary = "인증 번호 전송 API", description = "인증 번호를 이메일로 보낸다.")
+    public ApiResponse<String> sendMessage() {
+        mailService.sendCodeToEmail();
+        return ApiResponse.onSuccess("인증번호 전송이 완료되었습니다.");
+    }
+
+    @Operation(summary = "인증 번호 검증 API", description = "이메일로 전송 받은 인증번호를 입력한다.")
+    @PostMapping("/verification")
+    public ApiResponse<String> verificationEmail(@RequestBody @Valid TokenRequestDTO.AuthCodeRequestDTO request) {
+        mailService.verifiedCode(request.getAuthCode());
+        return ApiResponse.onSuccess("성공적으로 인증되었습니다.");
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenRequestDTO.java
@@ -44,6 +44,21 @@ public class TokenRequestDTO {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class ResetPasswordRequestDTO {
+
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @Schema(example = "password1234!", description = "사용자의 비밀번호")
+        private String newPassword;
+
+        @NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
+        @Schema(example = "password1234!", description = "사용자의 비밀번호")
+        private String checkNewPassword;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class LoginTokenRequestDTO {
 
         @NotBlank(message = "이메일은 필수 입력 항목입니다.")
@@ -109,4 +124,18 @@ public class TokenRequestDTO {
         @Schema(example = "eKD_mr9SG0XftaFoKFB9L5ABA91bF1cpjv7g6Khw...", description = "유효한 refresh Token")
         private String refreshToken;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AuthCodeRequestDTO{
+        @NotBlank
+        @Schema(example = "123456", description = "유효한 인증코드")
+        private String authCode;
+    }
+
+
+
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/mail/EmailConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/mail/EmailConfig.java
@@ -1,0 +1,68 @@
+package chungbazi.chungbazi_be.domain.auth.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/MailService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/MailService.java
@@ -1,0 +1,101 @@
+package chungbazi.chungbazi_be.domain.auth.service;
+
+import chungbazi.chungbazi_be.domain.user.entity.User;
+import chungbazi.chungbazi_be.domain.user.utils.UserHelper;
+import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
+import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Random;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MailService {
+    private static final String AUTH_CODE_PREFIX = "AuthCode ";
+
+    private static final long authCodeExpirationMillis = 1000 * 60 * 30;
+
+    private final TokenAuthService tokenAuthService;
+    private final UserHelper userHelper;
+    private final JavaMailSender emailSender;
+
+    public void sendEmail(String toEmail,
+                          String title,
+                          String text) {
+        SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+        try {
+            emailSender.send(emailForm);
+        } catch (RuntimeException e) {
+            log.debug("MailService.sendEmail exception occur toEmail: {}, " +
+                    "title: {}, text: {}", toEmail, title, text);
+            throw new BadRequestHandler(ErrorStatus.UNABLE_TO_SEND_EMAIL);
+        }
+    }
+
+    // 발신할 이메일 데이터 세팅
+    private SimpleMailMessage createEmailForm(String toEmail,
+                                              String title,
+                                              String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+
+    public void sendCodeToEmail() {
+        User user = userHelper.getAuthenticatedUser();
+        String toEmail = user.getEmail();
+        String title = "청바지 이메일 인증 번호";
+        String authCode = this.createCode();
+        String content = String.format("""
+            안녕하세요, 청바지입니다. 👖
+
+            요청하신 이메일 인증을 위해 아래 인증번호를 입력해주세요.
+            인증번호: %s
+
+            감사합니다.
+            """, authCode);
+        sendEmail(toEmail, title, content);
+
+        // 이메일 인증 요청 시 인증 번호 Redis에 저장 ( key = "AuthCode " + Email / value = AuthCode )
+        tokenAuthService.setAuthCode(AUTH_CODE_PREFIX + toEmail,
+                authCode, Duration.ofMillis(authCodeExpirationMillis));
+    }
+
+    private String createCode() {
+        int length = 6;
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < length; i++) {
+                builder.append(random.nextInt(10));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new BadRequestHandler(ErrorStatus.NO_SUCH_ALGORITHM);
+        }
+    }
+
+    public void verifiedCode( String authCode) {
+        User user = userHelper.getAuthenticatedUser();
+        String email = user.getEmail();
+        String redisAuthCode = tokenAuthService.getAuthCode(AUTH_CODE_PREFIX + email);
+        boolean authResult = tokenAuthService.checkExistsAuthCode(redisAuthCode) && redisAuthCode.equals(authCode);
+        if (!authResult) {
+            throw new BadRequestHandler(ErrorStatus.INVALID_AUTHCODE);
+        }
+    }
+
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/TokenAuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/TokenAuthService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -60,6 +61,18 @@ public class TokenAuthService {
         if (isBlackListed(token)) {
             throw new BadRequestHandler(ErrorStatus.BLOCKED_TOKEN);
         }
+    }
+
+    public void setAuthCode(String key, String value, Duration duration) {
+        redisTemplate.opsForValue().set(key, value, duration);
+    }
+
+    public String getAuthCode(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean checkExistsAuthCode(String value) {
+        return value != null && !value.isEmpty();
     }
 }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
@@ -118,6 +118,7 @@ public class User {
     public void updateRegion(Region region) { this.region = region;}
     public void updateIsDeleted(Boolean isDeleted){this.isDeleted = isDeleted;}
     public void updateRewardLevel(RewardLevel reward) {this.reward = reward;}
+    public void updatePassword(String newPassword) {this.password = newPassword;}
 
     // 알람 관련
     public void updateNotificationSetting(NotificationSetting notificationSetting) {this.notificationSetting = notificationSetting;}

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -2,6 +2,7 @@ package chungbazi.chungbazi_be.global.apiPayload.code.status;
 
 import chungbazi.chungbazi_be.global.apiPayload.code.BaseErrorCode;
 import chungbazi.chungbazi_be.global.apiPayload.code.ErrorReasonDTO;
+import com.google.api.Http;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -62,6 +63,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "TOKEN4018", "잘못된 인자가 제공되었습니다."),
     BLOCKED_TOKEN(HttpStatus.FORBIDDEN, "TOKEN4019", "차단된 사용자의 토큰입니다."),
     DEACTIVATED_ACCOUNT(HttpStatus.BAD_REQUEST, "TOKEN4020", "삭제된 계정입니다."),
+    UNABLE_TO_SEND_EMAIL(HttpStatus.BAD_REQUEST,"TOKEN4021","이메일을 보낼 수 없습니다."),
+    NO_SUCH_ALGORITHM(HttpStatus.BAD_REQUEST,"TOKEN4022","인증 코드 생성 중 문제가 발생했습니다."),
+    INVALID_AUTHCODE(HttpStatus.BAD_REQUEST,"TOKEN4023","인증코드가 불일치 합니다."),
 
     //s3 관련 에러
     NO_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "UPLOAD400", "파일의 이름에 확장자가 존재하지 않습니다."),


### PR DESCRIPTION
## 연관 이슈

close #95 

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
- 이메일 인증번호 전송 및 검증 기능을 구현한다.
- 비밀번호 재설정 기능을 구현한다.

<br/>

## ✅ 작업 내용
google SMTP 사용했고, yml 파일에 mail 부분 추가했습니다.
비밀번호 재설정은 authController, authService
이메일 인증번호 관련은 mailController, mailService로 분리했습니다.
비밀번호 재설정 기존 비밀번호와 동일할 경우 불가 등과 같은 오류처리는 추후 리팩토링 예정

- 이메일로 인증번호 전송 : 사용자의 이메일 정보를 가져와서 전송
<img width="924" alt="스크린샷 2025-05-18 오전 7 33 44" src="https://github.com/user-attachments/assets/4f9d79f7-d910-4491-92ce-f189917e5d7a" />

- 전송된 이메일 캡처
<img width="684" alt="스크린샷 2025-05-18 오전 7 33 59" src="https://github.com/user-attachments/assets/895d66e1-c037-4902-8f82-b2af5a1bb095" />

- 인증번호 검증
<img width="868" alt="스크린샷 2025-05-18 오전 7 39 08" src="https://github.com/user-attachments/assets/9afc5c7a-d909-4183-ab5d-00f8de0eda40" />

- 비밀번호 재설정 
<img width="868" alt="스크린샷 2025-05-18 오전 7 39 44" src="https://github.com/user-attachments/assets/37a491e5-6106-475f-9425-1833822cf318" />

- [x] 이메일 인증번호 전송
- [x] 인증번호 검증
- [x] 비밀번호 재설정

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
@dldusgh318 
	// Firebase Admin
    implementation('com.google.firebase:firebase-admin:9.2.0') {
        exclude group: 'javax.mail'
        exclude group: 'jakarta.mail'
        exclude group: 'com.sun.mail'
    } -> 의존성 충돌로 3가지 부분 제외했습니다! 혹시 사용하시는 부분이라면 말씀해 주세용