### PR TITLE
[feature] chatgpt 이용한 chatbot 구현

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/controller/ChatBotController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/controller/ChatBotController.java
@@ -5,7 +5,6 @@ import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotResponseDTO;
 import chungbazi.chungbazi_be.domain.chatbot.service.ChatBotService;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
-import com.google.protobuf.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.service.annotation.PostExchange;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/controller/ChatBotController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/controller/ChatBotController.java
@@ -1,0 +1,30 @@
+package chungbazi.chungbazi_be.domain.chatbot.controller;
+
+import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotResponseDTO;
+import chungbazi.chungbazi_be.domain.chatbot.service.ChatBotService;
+import chungbazi.chungbazi_be.domain.policy.entity.Category;
+import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chatbot")
+@Validated
+public class ChatBotController {
+    private final ChatBotService chatBotService;
+
+    @GetMapping("/policies")
+    @Operation(summary = "정책 찾기 API", description = "카테고리별 정책 찾기 API")
+    public ApiResponse<List<ChatBotResponseDTO.PolicyDto>> getCategoryPolicies(
+            @RequestParam(value = "category")Category category
+            ) {
+        return ApiResponse.onSuccess(chatBotService.getPolicies(category));
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/controller/ChatBotController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/controller/ChatBotController.java
@@ -1,17 +1,22 @@
 package chungbazi.chungbazi_be.domain.chatbot.controller;
 
+import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotRequestDTO;
 import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotResponseDTO;
 import chungbazi.chungbazi_be.domain.chatbot.service.ChatBotService;
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
+import com.google.protobuf.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.service.annotation.PostExchange;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +31,12 @@ public class ChatBotController {
             @RequestParam(value = "category")Category category
             ) {
         return ApiResponse.onSuccess(chatBotService.getPolicies(category));
+    }
+
+    @PostMapping("/ask")
+    @Operation(summary = "chatbot 질문 API", description = "chatbot 질문 API")
+    public ApiResponse<ChatBotResponseDTO.ChatDto> askGpt(@RequestBody ChatBotRequestDTO.ChatDto request){
+        String userMessage = request.getMessage();
+        return ApiResponse.onSuccess(chatBotService.askGpt(userMessage));
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/converter/ChatBotConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/converter/ChatBotConverter.java
@@ -15,4 +15,8 @@ public class ChatBotConverter {
                             .build()
                 ).toList();
     }
+
+    public static ChatBotResponseDTO.ChatDto toChatDto(String answer){
+        return ChatBotResponseDTO.ChatDto.builder().answer(answer).build();
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/converter/ChatBotConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/converter/ChatBotConverter.java
@@ -1,0 +1,18 @@
+package chungbazi.chungbazi_be.domain.chatbot.converter;
+
+import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotResponseDTO;
+import chungbazi.chungbazi_be.domain.policy.entity.Policy;
+import java.util.List;
+
+public class ChatBotConverter {
+    public static List<ChatBotResponseDTO.PolicyDto> toPolicyListDto(List<Policy> policies) {
+        return policies.stream()
+                .map(policy ->
+                    ChatBotResponseDTO.PolicyDto.builder()
+                            .policyId(policy.getId())
+                            .title(policy.getName())
+                            .category(policy.getCategory())
+                            .build()
+                ).toList();
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotRequestDTO.java
@@ -3,11 +3,15 @@ package chungbazi.chungbazi_be.domain.chatbot.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class ChatBotRequestDTO {
     @Getter
+    @Setter
     @Builder
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class ChatDto {
         String message;
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotRequestDTO.java
@@ -1,0 +1,14 @@
+package chungbazi.chungbazi_be.domain.chatbot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ChatBotRequestDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ChatDto {
+        String message;
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotResponseDTO.java
@@ -14,4 +14,11 @@ public class ChatBotResponseDTO {
         String title;
         Category category; //추후 추가
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ChatDto {
+        String answer;
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotResponseDTO.java
@@ -1,0 +1,17 @@
+package chungbazi.chungbazi_be.domain.chatbot.dto;
+
+import chungbazi.chungbazi_be.domain.policy.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ChatBotResponseDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class PolicyDto {
+        Long policyId;
+        String title;
+        Category category; //추후 추가
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
@@ -7,6 +7,7 @@ import chungbazi.chungbazi_be.domain.policy.entity.Policy;
 import chungbazi.chungbazi_be.domain.policy.repository.PolicyRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,9 +24,20 @@ public class ChatBotService {
     }
 
     public ChatBotResponseDTO.ChatDto askGpt(String userMessage){
+        if (isMeaningless(userMessage)) {
+            return ChatBotConverter.toChatDto("죄송해요, 정책과 관련된 질문을 해주세요.");
+        }
         String systemPrompt = "당신은 청년 정책을 설명해주는 챗봇입니다."; // 프롬프트 정적 지정
         String answer = chatGptClient.askChatGpt(userMessage, systemPrompt);
         return ChatBotConverter.toChatDto(answer);
     }
 
+    private boolean isMeaningless(String message){ //의미 없는 질문 방지
+        if (message == null || message.trim().isEmpty()) return true;
+
+        String trimmed = message.trim().replaceAll("[^ㄱ-ㅎ가-힣a-zA-Z0-9]", "");
+        if (trimmed.length() < 3) return true;
+
+        return false;
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
@@ -1,0 +1,24 @@
+package chungbazi.chungbazi_be.domain.chatbot.service;
+
+import chungbazi.chungbazi_be.domain.chatbot.converter.ChatBotConverter;
+import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotResponseDTO;
+import chungbazi.chungbazi_be.domain.policy.entity.Category;
+import chungbazi.chungbazi_be.domain.policy.entity.Policy;
+import chungbazi.chungbazi_be.domain.policy.repository.PolicyRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatBotService {
+    private final PolicyRepository policyRepository;
+
+    public List<ChatBotResponseDTO.PolicyDto> getPolicies(Category category) {
+        List<Policy> policies = policyRepository.findTop5ByCategoryOrderByCreatedAtDesc(category);
+        return ChatBotConverter.toPolicyListDto(policies);
+    }
+
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
@@ -7,7 +7,6 @@ import chungbazi.chungbazi_be.domain.policy.entity.Policy;
 import chungbazi.chungbazi_be.domain.policy.repository.PolicyRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatBotService.java
@@ -15,10 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatBotService {
     private final PolicyRepository policyRepository;
+    private final ChatGptClient chatGptClient;
 
     public List<ChatBotResponseDTO.PolicyDto> getPolicies(Category category) {
         List<Policy> policies = policyRepository.findTop5ByCategoryOrderByCreatedAtDesc(category);
         return ChatBotConverter.toPolicyListDto(policies);
+    }
+
+    public ChatBotResponseDTO.ChatDto askGpt(String userMessage){
+        String systemPrompt = "당신은 청년 정책을 설명해주는 챗봇입니다."; // 프롬프트 정적 지정
+        String answer = chatGptClient.askChatGpt(userMessage, systemPrompt);
+        return ChatBotConverter.toChatDto(answer);
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatGptClient.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/service/ChatGptClient.java
@@ -1,0 +1,40 @@
+package chungbazi.chungbazi_be.domain.chatbot.service;
+
+import chungbazi.chungbazi_be.global.utils.OpenAiProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class ChatGptClient {
+    private final OpenAiProperties openAiProperties;
+
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://api.openai.com/v1/chat/completions")
+            .defaultHeader("Content-Type", "application/json")
+            .build();
+
+    public String askChatGpt(String userMessage, String systemPrompt){
+        Map<String, Object> requestBody = Map.of(
+                "model", openAiProperties.getModel(),
+                "messages", List.of(
+                        Map.of("role","system", "content", systemPrompt),
+                        Map.of("role", "user", "content", userMessage)
+                ),
+                "temperature", 0.7
+        );
+
+        return webClient.post()
+                .uri("")
+                .header("Authorization", "Bearer " + openAiProperties.getApiKey())
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(json -> json.get("choices").get(0).get("message").get("content").asText())
+                .block();
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/repository/PolicyRepository.java
@@ -1,9 +1,14 @@
 package chungbazi.chungbazi_be.domain.policy.repository;
 
+import chungbazi.chungbazi_be.domain.policy.entity.Category;
 import chungbazi.chungbazi_be.domain.policy.entity.Policy;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PolicyRepository extends JpaRepository<Policy, Long>, PolicyRepositoryCustom {
 
     boolean existsByBizId(String bizId);
+
+    //챗봇 정책찾기용 -> 추후 수정 예정
+    List<Policy> findTop5ByCategoryOrderByCreatedAtDesc(Category category);
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/OpenAiProperties.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/OpenAiProperties.java
@@ -1,12 +1,14 @@
 package chungbazi.chungbazi_be.global.utils;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties(prefix = "openai")
 @Getter
+@Setter
 public class OpenAiProperties {
     private String apiKey;
     private String model;

--- a/src/main/java/chungbazi/chungbazi_be/global/utils/OpenAiProperties.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/utils/OpenAiProperties.java
@@ -1,0 +1,14 @@
+package chungbazi.chungbazi_be.global.utils;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "openai")
+@Getter
+public class OpenAiProperties {
+    private String apiKey;
+    private String model;
+    private String url;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,3 +70,8 @@ cloud:
     credentials:
       accessKey: ${AWS_ACCESS_KEY}
       secretKey: ${AWS_SECRET_ACCESS_KEY}
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+  model: gpt-3.5-turbo
+  url: https://api.openai.com/v1/chat/completions


### PR DESCRIPTION
## 연관 이슈

#99

<br/>

## 개요

chatgpt 이용한 chatbot 구현

<br/>

## ✅ 작업 내용

- [ ] 카테고리별 정책 찾기 API
<img width="868" alt="image" src="https://github.com/user-attachments/assets/0bf8667e-b49f-4b42-b3b7-2e4b8f724677" />

피그마에서 정책 찾기 버튼 클릭 시 카테고리 6가지 주어지고, 각 카테고리마다 우선 최신순 5개 보여지도록 구현했습니다.
정책 데이터가 없어서 임의로 데이터 넣어놓고 dto도 간략하게만 넣고 테스트해봤습니다.

<img width="280" alt="image" src="https://github.com/user-attachments/assets/cf0cb0ac-08eb-45ad-8ab5-02f59b78a239" />

@sh0311 저번에 질문드렸던 부분 답해주시면 감사하겠습니다!

- [ ] chatbot 질문 API
<img width="706" alt="image" src="https://github.com/user-attachments/assets/705cbb52-2b16-4a39-9782-6bab08f73239" />

gpt api key 발급받고 구현해놨습니다. 키 공유해놨으니, 환경 설정 부탁드립니다!


<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
