### PR TITLE
[Refactor] 상시 정책 반영 및 정책 파라미터 JsonProperty 수정

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/dto/YouthPolicyResponse.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/dto/YouthPolicyResponse.java
@@ -47,7 +47,7 @@ public class YouthPolicyResponse {
     @JsonProperty("sprtTrgtMinAge")
     private String sprtTrgtMinAge;  // 지원대상 최소 연령
 
-    @JsonProperty("ssprtTrgtMaxAge")
+    @JsonProperty("sprtTrgtMaxAge")
     private String sprtTrgtMaxAge;  // 지원대상 최대 연령
     /*
         @JacksonXmlProperty(localName = "majrRqisCn")
@@ -80,7 +80,7 @@ public class YouthPolicyResponse {
     @JsonProperty("aplyUrlAddr")
     private String aplyUrlAddr; // 신청 사이트 주소
 
-    @JsonProperty("lsbmsnDcmntCn")
+    @JsonProperty("sbmsnDcmntCn")
     private String sbmsnDcmntCn; // 제출 서류 내용
 
     @JsonProperty("srngMthdCn")

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -61,6 +61,10 @@ public class PolicyService {
     private final UserHelper userHelper;
     private final NotificationService notificationService;
 
+    private static final Set<String> VALID_KEYWORDS = Set.of(
+            "계속", "상시", "매년", "2025~", "연 2회", "별도 종료 시기 없음", "당해 연도"
+    );
+
 
     @Value("${webclient.openApiVlak}")
     private String openApiVlak;
@@ -214,18 +218,19 @@ public class PolicyService {
 
     // 날짜 나와있는지 + 2달 이내 정책인지 검증
     private boolean isDateAvail(YouthPolicyResponse response, LocalDate twoMonthAgo) {
-
         LocalDate endDate = response.getEndDate();
-
-        // 종료일 없는 경우지만 '계속'이면 출력 허용
-        if (endDate == null && "계속".equals(response.getBizPrdEtcCn())) {
-            return true; // 화면 출력 O, 날짜 필터링은 안 함
-        }
+        String bizPeriod = response.getBizPrdEtcCn();
 
         if (endDate == null) {
+            if (bizPeriod != null) {
+                for (String keyword : VALID_KEYWORDS) {
+                    if (bizPeriod.contains(keyword)) {
+                        return true;
+                    }
+                }
+            }
             return false;
         }
-
         return endDate.isAfter(twoMonthAgo);
     }
 


### PR DESCRIPTION
## 연관 이슈

close #109 

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
- 상시 정책이 반영되도록 수정한다.
- DB에서 파라미터 변경사항이 있는지 검토하고 수정한다.

<br/>

## ✅ 작업 내용
- 기본계획정책방향API의 경우는 JSON 내역을 확인해보니 카테고리 분류 관련 내용이었고, DB에도 카테고리별로 잘 받아오는 것 확인했습니다. (총 정책 53개)
<img width="643" alt="스크린샷 2025-06-28 오전 4 00 26" src="https://github.com/user-attachments/assets/0ae15cbc-4f70-46ce-b1ec-3ffa0c4fd38a" />

- PolicyService에서 VALID_KEYWORDS 따로 Set으로 설정해서 이후에 추가하기 쉽도록 수정했습니다.

- raw json에 document, ageMax 파리미터값이 있는데 DB에 저장되지 않아서, 코드 확인 결과 JsonProperty에 오타가 있어서 수정했고 local DB로 새로 DB create 해서 테스트 했을 때 저장되는 것 확인했습니다 -> ⭐️지금 사용하는 chungbazi DB 이후에 드롭하고 재생성해야될 것 같아요 document내역 저장이 안 되더라구요 DB 사용중이신 분이 계실 수도 있어서 따로 드롭하진 않았습니다!⭐️
<img width="754" alt="스크린샷 2025-06-28 오전 4 00 51" src="https://github.com/user-attachments/assets/666ad457-749a-4cf9-85ca-1f6e38d5bcf8" />
<img width="754" alt="스크린샷 2025-06-28 오전 4 00 58" src="https://github.com/user-attachments/assets/b490d535-d869-4750-a583-9354dcff7d1a" />

- policy 필드값중 employment가 있는데, Policy.builder()에서 employment가 빠져있고 승현님께서 제외하신 것 같아서 이 부분은 그대로 두었습니다!


<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
