### PR TITLE
[feature] 챗봇 dto 추가 및 DB 정책 반영

### DIFF
--- a/src/main/generated/chungbazi/chungbazi_be/domain/policy/entity/QPolicy.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/policy/entity/QPolicy.java
@@ -28,6 +28,8 @@ public class QPolicy extends EntityPathBase<Policy> {
 
     public final StringPath bizId = createString("bizId");
 
+    public final StringPath bizPrdEtcCn = createString("bizPrdEtcCn");
+
     public final EnumPath<Category> category = createEnum("category", Category.class);
 
     public final StringPath content = createString("content");

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/converter/ChatBotConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/converter/ChatBotConverter.java
@@ -2,26 +2,27 @@ package chungbazi.chungbazi_be.domain.chatbot.converter;
 
 import chungbazi.chungbazi_be.domain.chatbot.dto.ChatBotResponseDTO;
 import chungbazi.chungbazi_be.domain.policy.entity.Policy;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 public class ChatBotConverter {
-    public static List<ChatBotResponseDTO.PolicyDto> toPolicyListDto(List<Policy> policies) {
-        return policies.stream()
-                .map(policy ->
-                    ChatBotResponseDTO.PolicyDto.builder()
-                            .policyId(policy.getId())
-                            .title(policy.getName())
-                            .build()
-                ).toList();
+    public static ChatBotResponseDTO.PolicyDto toPolicyDto(Policy policy, LocalDate today, Set<String> validKeywords) {
+        return ChatBotResponseDTO.PolicyDto.builder()
+                .policyId(policy.getId())
+                .title(policy.getName())
+                .status(policy.getStatus(today, validKeywords))
+                .build();
     }
 
-    public static ChatBotResponseDTO.PolicyDetailDto toPolicyDetailDto(Policy policy) {
+    public static ChatBotResponseDTO.PolicyDetailDto toPolicyDetailDto(Policy policy, LocalDate today, Set<String> validKeywords) {
         return ChatBotResponseDTO.PolicyDetailDto.builder()
                 .policyId(policy.getId())
                 .title(policy.getName())
                 .category(policy.getCategory())
                 .intro(policy.getIntro())
                 .bizId(policy.getBizId())
+                .status(policy.getStatus(today, validKeywords))
                 .build();
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chatbot/dto/ChatBotResponseDTO.java
@@ -12,6 +12,7 @@ public class ChatBotResponseDTO {
     public static class PolicyDto {
         Long policyId;
         String title;
+        String status;
     }
 
     @Getter
@@ -22,7 +23,8 @@ public class ChatBotResponseDTO {
         String title;
         Category category;
         String intro;
-        String bizId; //신청 기간 추가
+        String bizId;
+        String status;
     }
 
     @Getter

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -56,6 +57,10 @@ public class Policy extends BaseTimeEntity {
 
     // 신청 끝나는 날짜 (상시모집이면 null 값으로 저장)
     private LocalDate endDate;
+
+    // 기타 정책 기간
+    @Column(length = 1000)
+    private String bizPrdEtcCn;
 
     // 최소 연령
     @Column(length = 1000)
@@ -144,6 +149,7 @@ public class Policy extends BaseTimeEntity {
                 .content(dto.getPlcySprtCn())
                 .startDate(dto.getStartDate())
                 .endDate(dto.getEndDate())
+                .bizPrdEtcCn(dto.getBizPrdEtcCn())
                 .minAge(dto.getSprtTrgtMinAge())
                 .maxAge(dto.getSprtTrgtMaxAge())
                 .minIncome(dto.getEarnMinAmt())
@@ -158,5 +164,33 @@ public class Policy extends BaseTimeEntity {
                 .referenceUrl1(dto.getRefUrlAddr1())
                 .referenceUrl2(dto.getRefUrlAddr2())
                 .build();
+    }
+
+    public String getStatus(LocalDate today, Set<String> validKeywords) {
+        if (bizPrdEtcCn != null) {
+            for (String keyword : validKeywords) {
+                if (bizPrdEtcCn.contains(keyword)) {
+                    return "상시";
+                }
+            }
+        }
+
+        if (startDate != null && startDate.isAfter(today)) {
+            return "예정";
+        }
+
+        if (startDate != null && endDate != null) {
+            if ((startDate.isEqual(today) || startDate.isBefore(today)) &&
+                    (endDate.isEqual(today) || endDate.isAfter(today))) {
+                return "진행중";
+            }
+        }
+
+        if (endDate != null && endDate.isBefore(today)) {
+            return "마감";
+        }
+
+        return "상시";
+
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
@@ -107,6 +107,7 @@ public class Policy extends BaseTimeEntity {
     */
 
     // 신청 사이트 주소
+    @Column(columnDefinition = "TEXT")
     private String registerUrl;
 
     // Open API 내 정책 ID
@@ -114,7 +115,7 @@ public class Policy extends BaseTimeEntity {
     private String bizId;
 
     // 제출 서류 내용
-    @Column(length = 1000)
+    @Column(columnDefinition = "TEXT")
     private String document;
 
     // 심사 발표 내용

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -62,7 +62,7 @@ public class PolicyService {
     private final UserHelper userHelper;
     private final NotificationService notificationService;
 
-    private static final Set<String> VALID_KEYWORDS = Set.of(
+    public static final Set<String> VALID_KEYWORDS = Set.of(
             "계속", "상시", "매년", "2025~", "연 2회", "별도 종료 시기 없음", "당해 연도"
     );
 


### PR DESCRIPTION
## 연관 이슈

#99 

<br/>

## 개요

챗봇 dto 추가 및 DB 정책 반영

<br/>

## ✅ 작업 내용

- [x] 챗봇 dto 추가
반영된 db 토대로 정책 신청 기간 따져서 dto에 추가해줬습니다.
<img width="462" alt="image" src="https://github.com/user-attachments/assets/cc9f8f81-cf0b-40c2-ae92-71d4be10c7e0" />

<img width="582" alt="image" src="https://github.com/user-attachments/assets/23df445a-9d19-4d3c-a7f5-d0c483a74a9a" />

- [x] DB 정책 반영
일단 기존에 api로 정책 호출하던 방식에서 스케줄러로 저장되도록 바꿨습니다.
<img width="846" alt="image" src="https://github.com/user-attachments/assets/abfff9c6-0a81-4e75-8657-c74fb96fb4db" />
해당 시간에 맞춰서 디비에 잘 저장되는지 확인하긴 했는데, 서버에 배포되어서도 잘 동작하는지는 확인해봐야 할 것 같습니다!

<br/>

### 📝 논의사항

아직 피그마에서 답변을 못 받은 상태이긴 한데
<img width="333" alt="image" src="https://github.com/user-attachments/assets/722449ba-d7ea-4871-97c3-99c6c3510e65" />

이렇게 전국..? 처럼 시군구코드가 필요해질 것 같아서... 만약 위치가 추가되어야 한다면 이 부분도 논의해봐야 할 것 같습니다!
