### PR TITLE
feat: 대댓글 기능 추가 (#132)

### DIFF
--- a/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QComment.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QComment.java
@@ -26,6 +26,8 @@ public class QComment extends EntityPathBase<Comment> {
 
     public final chungbazi.chungbazi_be.domain.user.entity.QUser author;
 
+    public final ListPath<Comment, QComment> childComments = this.<Comment, QComment>createList("childComments", Comment.class, QComment.class, PathInits.DIRECT2);
+
     public final StringPath content = createString("content");
 
     //inherited
@@ -34,6 +36,8 @@ public class QComment extends EntityPathBase<Comment> {
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final NumberPath<Integer> likesCount = createNumber("likesCount", Integer.class);
+
+    public final QComment parentComment;
 
     public final QPost post;
 
@@ -65,6 +69,7 @@ public class QComment extends EntityPathBase<Comment> {
     public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.author = inits.isInitialized("author") ? new chungbazi.chungbazi_be.domain.user.entity.QUser(forProperty("author"), inits.get("author")) : null;
+        this.parentComment = inits.isInitialized("parentComment") ? new QComment(forProperty("parentComment"), inits.get("parentComment")) : null;
         this.post = inits.isInitialized("post") ? new QPost(forProperty("post"), inits.get("post")) : null;
     }
 

--- a/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QComment.java
+++ b/src/main/generated/chungbazi/chungbazi_be/domain/community/entity/QComment.java
@@ -35,6 +35,8 @@ public class QComment extends EntityPathBase<Comment> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
     public final NumberPath<Integer> likesCount = createNumber("likesCount", Integer.class);
 
     public final QComment parentComment;

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
@@ -91,6 +91,7 @@ public class CommunityConverter {
                 .characterImg(comment.getAuthor().getCharacterImg())
                 .commentId(comment.getId())
                 .isLikedByUser(isLikedByUser)
+                .parentCommentId(comment.getParentComment()!=null ? comment.getParentComment().getId() : null)
                 .build();
     }
 //    public static List<CommunityResponseDTO.UploadAndGetCommentDto> toListCommentDto(List<Comment> comments, Long currentUserId) {

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
@@ -92,6 +92,7 @@ public class CommunityConverter {
                 .commentId(comment.getId())
                 .isLikedByUser(isLikedByUser)
                 .parentCommentId(comment.getParentComment()!=null ? comment.getParentComment().getId() : null)
+                .isDeleted(comment.isDeleted())
                 .build();
     }
 //    public static List<CommunityResponseDTO.UploadAndGetCommentDto> toListCommentDto(List<Comment> comments, Long currentUserId) {

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityRequestDTO.java
@@ -1,6 +1,7 @@
 package chungbazi.chungbazi_be.domain.community.dto;
 
 import chungbazi.chungbazi_be.domain.policy.entity.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -37,5 +38,8 @@ public class CommunityRequestDTO {
         @NotBlank
         @Size(min = 1, max = 100, message = "댓글은 100자 이하")
         String content;
+
+        @Schema(description = "대댓글일 때의, 부모 댓글 id", example = "안녕하세요")
+        private Long parentCommentId;
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityResponseDTO.java
@@ -89,6 +89,7 @@ public class CommunityResponseDTO {
         Integer likesCount;
         boolean isLikedByUser;
         boolean isMine;
+        Long parentCommentId;
     }
 
     @Getter

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityResponseDTO.java
@@ -90,6 +90,7 @@ public class CommunityResponseDTO {
         boolean isLikedByUser;
         boolean isMine;
         Long parentCommentId;
+        boolean isDeleted;
     }
 
     @Getter

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Comment.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Comment.java
@@ -58,6 +58,12 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parentComment", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Comment> childComments = new ArrayList<>();
 
+    private boolean isDeleted = false;
+
+    public void markAsDeleted() {
+        isDeleted = true;
+    }
+
     public void incrementLike(){this.likesCount = this.likesCount + 1;}
 
     public void decrementLike(){

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Comment.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/entity/Comment.java
@@ -11,6 +11,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -47,6 +50,13 @@ public class Comment extends BaseTimeEntity {
     @Builder.Default
     @Column(columnDefinition = "integer default 0")
     private Integer likesCount = 0;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Comment> childComments = new ArrayList<>();
 
     public void incrementLike(){this.likesCount = this.likesCount + 1;}
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -153,6 +153,13 @@ public class CommunityService {
         Post post = postRepository.findById(uploadCommentDto.getPostId())
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_POST));
 
+        //부모 댓글이 있는지 확인
+        Comment parentComment = null;
+        if (uploadCommentDto.getParentCommentId() !=null){
+            parentComment = commentRepository.findById(uploadCommentDto.getParentCommentId())
+                    .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_COMMENT));
+        }
+
         // 유저 조회
         User user = userHelper.getAuthenticatedUser();
         Comment comment = Comment.builder().
@@ -160,6 +167,7 @@ public class CommunityService {
                 .author(user)
                 .post(post)
                 .status(ContentStatus.VISIBLE)
+                .parentComment(parentComment)
                 .build();
 
         commentRepository.save(comment);

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -335,7 +335,8 @@ public class CommunityService {
             throw new BadRequestHandler(ErrorStatus.UNABLE_TO_DELETE_COMMENT);
         }
 
-        commentRepository.delete(comment);
+        comment.markAsDeleted();
+        commentRepository.save(comment);
     }
 
     public void likeComment(Long commentId) {


### PR DESCRIPTION
## 연관 이슈

close #132 

<br/>

## 개요

대댓글 기능 만들었습니다. 
<img width="721" height="684" alt="스크린샷 2025-09-24 오후 4 13 39" src="https://github.com/user-attachments/assets/2da69efd-a675-431a-b915-bca73985dab9" />

<img width="717" height="685" alt="스크린샷 2025-09-24 오후 4 13 51" src="https://github.com/user-attachments/assets/56403166-d567-427d-bd20-602614258ed3" />

<img width="721" height="586" alt="스크린샷 2025-09-24 오후 4 14 04" src="https://github.com/user-attachments/assets/3f7cc635-049e-4781-99b6-1b1f1ed3a80e" />

사진과 같이 대댓글을 단 경우, 부모 댓글 id를 보내고, 댓글인 경우에는 부모 id를 null로 보냅니다

그리고 대댓글 기능을 추가하면서, 댓글 삭제 방식도 soft delete로 변경하였습니다.
<img width="718" height="391" alt="image" src="https://github.com/user-attachments/assets/7c83f845-cf47-4b65-8d5b-e8aff7b6838e" />
<img width="721" height="397" alt="image" src="https://github.com/user-attachments/assets/7603ed28-1f88-4898-931f-397cc117428a" />

다음과 같이 기존 부모 댓글이 삭제되어도, 자식 댓글은 그대로 남아있는 걸 볼 수 있습니당
<br/>

## ✅ 작업 내용

- [x] 대댓글 기능 추가
- [x] 댓글 삭제 soft delete로 변경

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
