### PR TITLE
[feat] 좋아요 알림 로직 추가

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/cart/service/CartService.java
@@ -170,7 +170,7 @@ public class CartService {
         if (notificationDate.isAfter(LocalDate.now())) {
             taskScheduler.schedule(() -> {
                 String message = policy.getName() + "가 3일 뒤 마감됩니다!";
-                notificationService.sendNotification(user, NotificationType.POLICY_ALARM, message, null, policy,null);
+                notificationService.sendNotification(user, NotificationType.POLICY_ALARM, message, null, policy,null,null);
             }, notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
         }
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/chat/service/ChatService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chat/service/ChatService.java
@@ -118,7 +118,7 @@ public class ChatService {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
         if(chatRoomSettingService.getChatRoomSettingIsEnabled(receiverId,chat.getChatRoom().getId())){
             String message = chat.getSender().getName() + "님이 쪽지를 보내셨습니다.";
-            notificationService.sendNotification(receiver, NotificationType.CHAT_ALARM,message,null,null,chat);
+            notificationService.sendNotification(receiver, NotificationType.CHAT_ALARM,message,null,null,chat,null);
         }
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/CommunityService.java
@@ -175,7 +175,23 @@ public class CommunityService {
         if(user.getNotificationSetting().isCommunityAlarm() && !user.getId().equals(post.getAuthor().getId())){
             sendCommunityNotification(post.getId());
         }
-
+        if (parentComment != null) {
+            User parentAuthor = parentComment.getAuthor();
+            // 부모 댓글 작성자가 댓글 작성자 자신이 아닐 때만 알림
+            if (user.getNotificationSetting().isCommunityAlarm()
+                    && !parentAuthor.getId().equals(user.getId())) {
+                String message = user.getName() + "님이 회원님의 댓글에 답글을 달았습니다.";
+                notificationService.sendNotification(
+                        parentAuthor,
+                        NotificationType.COMMUNITY_ALARM,
+                        message,
+                        post,
+                        null,
+                        null,
+                        null
+                );
+            }
+        }
         rewardService.checkRewards();
 
         return CommunityConverter.toUploadAndGetCommentDto(comment, user.getId(),false);

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/service/RewardService.java
@@ -59,7 +59,7 @@ public class RewardService {
         User user=userHelper.getAuthenticatedUser();
         String message = rewardLevel + "단계에 달성하여 캐릭터가 지급되었습니다.";
 
-        notificationService.sendNotification(user, NotificationType.REWARD_ALARM, message, null, null, null);
+        notificationService.sendNotification(user, NotificationType.REWARD_ALARM, message, null, null, null,null);
     }
 
     public NextLevelInfo calNextLevelInfo(User user, Character character){

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package chungbazi.chungbazi_be.domain.notification.entity;
 
 import chungbazi.chungbazi_be.domain.chat.entity.Message;
+import chungbazi.chungbazi_be.domain.community.entity.Comment;
 import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.global.utils.TimeFormatter;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
@@ -40,6 +41,10 @@ public class Notification extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
 
     // 정책 알림인 경우 (선택적)
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package chungbazi.chungbazi_be.domain.notification.service;
 
 import chungbazi.chungbazi_be.domain.auth.jwt.SecurityUtils;
+import chungbazi.chungbazi_be.domain.community.entity.Comment;
 import chungbazi.chungbazi_be.domain.community.entity.Post;
 import chungbazi.chungbazi_be.domain.notification.converter.NotificationConverter;
 import chungbazi.chungbazi_be.domain.notification.dto.NotificationResponseDTO;
@@ -43,7 +44,7 @@ public class NotificationService {
     private final NotificationSettingRepository notificationSettingRepository;
     private final UserHelper userHelper;
 
-    public NotificationResponseDTO.responseDto sendNotification(User user, NotificationType type, String message, Post post, Policy policy, chungbazi.chungbazi_be.domain.chat.entity.Message chat) {
+    public NotificationResponseDTO.responseDto sendNotification(User user, NotificationType type, String message, Post post, Policy policy, chungbazi.chungbazi_be.domain.chat.entity.Message chat, Comment comment) {
         Notification notification=Notification.builder()
                 .user(user)
                 .type(type)
@@ -52,6 +53,7 @@ public class NotificationService {
                 .post(post)
                 .policy(policy)
                 .chat(chat)
+                .comment(comment)
                 .build();
 
         notificationRepository.save(notification);
@@ -62,8 +64,9 @@ public class NotificationService {
             Long policyId = (policy != null) ? policy.getId() : null;
             Long postId = (post != null) ? post.getId() : null;
             Long chatId = (chat != null) ? chat.getId() : null;
+            Long commentId = (comment != null) ? comment.getId() : null;
 
-            pushFCMNotification(fcmToken,message,policyId, postId, chatId,type);
+            pushFCMNotification(fcmToken,message,policyId, postId, chatId,commentId,type);
         }
         return NotificationResponseDTO.responseDto.builder()
                 .notificationId(notification.getId())
@@ -72,7 +75,7 @@ public class NotificationService {
     }
 
     //fcm한테 알림 요청
-    public void pushFCMNotification(String fcmToken,String message,Long policyId, Long postId, Long chatId, NotificationType type) {
+    public void pushFCMNotification(String fcmToken,String message,Long policyId, Long postId, Long chatId, Long commentId,NotificationType type) {
         try {
             com.google.firebase.messaging.Notification notification =
                     com.google.firebase.messaging.Notification.builder()
@@ -89,6 +92,9 @@ public class NotificationService {
             }
             if (chatId != null) {
                 data.put("chatId", chatId.toString());
+            }
+            if (commentId != null) {
+                data.put("commentId", commentId.toString());
             }
             data.put("notificationType", type.toString());
 


### PR DESCRIPTION
## 연관 이슈

close #134 

<br/>

## 개요

좋아요 기능과 관련된 알림 전송 로직이 없어서 추가하였다.
그리고 대댓글 알림 전송 시에는 부모댓글 작성자에게도 알림을 보내야할 거 같아, 해당 부분도 추가하였다

<br/>

## ✅ 작업 내용

- [x] 좋아요 알림 전송 로직 추가
- [x] 대댓글 업로드 시, 부모 댓글 작성자에게 알림 전송

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
