### PR TITLE
[feat] 부모댓글 대댓글 수 응답값에 추가 (#139)

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/converter/CommunityConverter.java
@@ -75,7 +75,7 @@ public class CommunityConverter {
                 .build();
     }
 
-    public static CommunityResponseDTO.UploadAndGetCommentDto toUploadAndGetCommentDto(Comment comment, Long currentUserId,boolean isLikedByUser) {
+    public static CommunityResponseDTO.UploadAndGetCommentDto toUploadAndGetCommentDto(Comment comment, Long currentUserId,boolean isLikedByUser, int replyCount) {
         boolean isMine = false;
         if (currentUserId != null && comment.getAuthor() != null) {
             isMine = currentUserId.equals(comment.getAuthor().getId());
@@ -94,6 +94,7 @@ public class CommunityConverter {
                 .isLikedByUser(isLikedByUser)
                 .parentCommentId(comment.getParentComment()!=null ? comment.getParentComment().getId() : null)
                 .isDeleted(comment.isDeleted())
+                .replyCount(replyCount)
                 .comments(new ArrayList<>())
                 .build();
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/community/dto/CommunityResponseDTO.java
@@ -94,6 +94,7 @@ public class CommunityResponseDTO {
         Long parentCommentId;
         boolean isDeleted;
 
+        int replyCount;
         List<UploadAndGetCommentDto> comments = new ArrayList<>();
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -273,7 +273,9 @@ public class PolicyService {
 
         YearMonth parsedYearMonth = YearMonth.parse(yearMonth, DateTimeFormatter.ofPattern("yyyy-M"));
         int year = parsedYearMonth.getYear();
+        log.info("파싱 확인 year: "+year);
         int month = parsedYearMonth.getMonthValue();
+        log.info("파싱 확인 month: "+month);
 
         Long userId = SecurityUtils.getUserId();
         return cartService.findByUser_IdAndYearMonth(userId, year, month);


### PR DESCRIPTION
## 연관 이슈

close #139

<br/>

## 개요

게시글의 전체 댓글 조회 시 부모댓글의 대댓글 수도 필요하여 응답에 추가했습니다.
<img width="724" height="395" alt="image" src="https://github.com/user-attachments/assets/e9057cfd-5c1b-4c67-95ce-efa026c52392" />


### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
