### PR TITLE
[fix] 채팅방 리스트 조회 시 에러 (#153)

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chat/controller/ChatController.java
@@ -31,8 +31,8 @@ public class ChatController {
 
     @PostMapping("/chat/{postId}/create-room")
     @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API입니다.")
-    public ChatResponseDTO.createChatRoomResponse createChatRoom(@PathVariable Long postId){
-        return chatService.createChatRoom(postId);
+    public ChatResponseDTO.createChatRoomResponse createChatRoom(@PathVariable Long postId, @RequestParam Long receiverId){
+        return chatService.createChatRoom(postId,receiverId);
     }
 
     @MessageMapping("/chat.message.{chatRoomId}")

--- a/src/main/java/chungbazi/chungbazi_be/domain/chat/service/ChatService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/chat/service/ChatService.java
@@ -21,6 +21,7 @@ import chungbazi.chungbazi_be.domain.user.service.UserBlockService;
 import chungbazi.chungbazi_be.domain.user.utils.UserHelper;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.GeneralException;
+import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
 import chungbazi.chungbazi_be.global.utils.PaginationResult;
 import chungbazi.chungbazi_be.global.utils.PaginationUtil;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -48,19 +50,25 @@ public class ChatService {
     private final ChatRoomSettingService chatRoomSettingService;
 
     @Transactional
-    public ChatResponseDTO.createChatRoomResponse createChatRoom(Long postId){
+    public ChatResponseDTO.createChatRoomResponse createChatRoom(Long postId, Long receiverId){
         User sender = userHelper.getAuthenticatedUser();
+
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_POST));
+
+        if (sender.getId().equals(receiverId)){
+            throw new BadRequestHandler(ErrorStatus.CAN_NOT_CHATTING_MYSELF);
+        }
 
         ChatRoom chatRoom=ChatRoom.builder()
                 .post(post)
                 .isActive(true)
                 .build();
 
-        //chatRoomRepository.save(chatRoom);
-
-        List<User> participants = List.of(sender, post.getAuthor());
+        List<User> participants = List.of(sender, receiver);
         participants.forEach(user -> {
             ChatRoomSetting setting = ChatRoomSetting.builder()
                     .user(user)
@@ -146,9 +154,11 @@ public class ChatService {
 
         boolean chatRoomIsEnabled= chatRoomSettingService.getChatRoomSettingIsEnabled(currentUser.getId(), chatRoom.getId());
 
+
         if (userBlockRepository.existsBlockBetweenUsers(currentUser.getId(), other.getId())){
             throw new GeneralException(ErrorStatus.BLOCKED_CHATROOM);
         }
+
 
         markMessagesAsRead(chatRoom,currentUser);
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/ChatRoomSettingService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/ChatRoomSettingService.java
@@ -20,7 +20,7 @@ public class ChatRoomSettingService {
 
     public boolean getChatRoomSettingIsEnabled(Long userId, Long roomId) {
         ChatRoomSetting chatRoomSetting= chatRoomSettingRepository.findByUserIdAndChatRoomId(userId,roomId)
-                .orElseThrow(()->new NotFoundHandler(ErrorStatus.NOT_FOUND_CHATROOMSETTING));
+                .orElseThrow(()->new NotFoundHandler(ErrorStatus.NOT_FOUND_CHATROOM_SETTING));
 
         return chatRoomSetting.isEnabled();
     }
@@ -31,7 +31,7 @@ public class ChatRoomSettingService {
         ChatRoom chatRoom = chatRoomService.getChatRoomById(chatRoomId);
 
         ChatRoomSetting chatRoomSetting= chatRoomSettingRepository.findByUserIdAndChatRoomId(user.getId(),chatRoomId)
-                .orElseThrow(()->new NotFoundHandler(ErrorStatus.NOT_FOUND_CHATROOMSETTING));
+                .orElseThrow(()->new NotFoundHandler(ErrorStatus.NOT_FOUND_CHATROOM_SETTING));
 
         chatRoomSetting.updateChatNotification(enabled);
         chatRoomSettingRepository.save(chatRoomSetting);

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -92,7 +92,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ACCESS_DENIED_CHATROOM(HttpStatus.FORBIDDEN, "CHATROOM400", "채팅방에 접근할 권한이 없습니다."),
     NOT_FOUND_MESSAGE(HttpStatus.NOT_FOUND,"MESSAGE400","존재하지 않는 메세지입니다."),
     BLOCKED_CHATROOM(HttpStatus.FORBIDDEN,"CHATROOM401","차단된 채팅방입니다."),
-    NOT_FOUND_CHATROOMSETTING(HttpStatus.NOT_FOUND, "CHATROOMSETTING404", "존재하지 않는 채팅방 알림 설정입니다."),
+    NOT_FOUND_CHATROOM_SETTING(HttpStatus.NOT_FOUND, "CHATROOMSETTING404", "존재하지 않는 채팅방 알림 설정입니다."),
+    CAN_NOT_CHATTING_MYSELF(HttpStatus.BAD_REQUEST, "CHATROOMS405", "자기 자신에게 쪽지를 보낼 수 없습니다."),
+    NOT_FOUND_OTHER_USER(HttpStatus.NOT_FOUND, "CHATROOM406", "채팅방에 참여한 다른 유저를 찾을 수 없습니다."),
 
 
     //차단 관련 에러


### PR DESCRIPTION
## 연관 이슈

close #153

<br/>

## 개요

채팅방 리스트 조회 시 다음과 같은 에러가 떴었다.
<img width="593" height="98" alt="image" src="https://github.com/user-attachments/assets/aad3f9da-5a8e-4ab6-928b-11e71c186824" />

이전에는 채팅이 글 작성자한테만 보낼 수 있었는데, 이때 글 작성자와 채팅 보내는 유저가 같은지 체크하지않아 발생한 에러였다. 따라서 이 부분을 에러처리하였다

추가로 이제는 채팅을 글 작성자 뿐만이 아니라 댓글 유저한테도 보낼 수 있어, 로직을 수정하였다

<br/>

## ✅ 작업 내용

- [x] 채팅 보내는 유저와 글 작성자가 같다면 에러처리
- [x] 채팅방 생성 로직 수정

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 채팅방 생성 시 특정 사용자를 받는 사람으로 선택할 수 있도록 개선되었습니다.

* **Bug Fixes**
  * 자신에게 쪽지를 보내는 것을 방지하도록 검증 로직이 추가되었습니다.
  * 존재하지 않는 사용자와의 채팅방 생성 시도를 감지합니다.

* **Chores**
  * 에러 상태 코드 정비 및 표준화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->