### PR TITLE
[fix] STOMP 연결 인증 및 WebSocket handshake 수정

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/jwt/JwtProvider.java
@@ -1,22 +1,31 @@
 package chungbazi.chungbazi_be.domain.auth.jwt;
 
+import chungbazi.chungbazi_be.domain.auth.service.CustomUserDetailsService;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Date;
 
 @Component
-public class JwtProvider {
+public class JwtProvider{
 
     private final Key key;
+    public final UserDetailsService userDetailsService;
 
-    public JwtProvider(@Value("${jwt.secret-key}") String secretKey) {
+    public JwtProvider(@Value("${jwt.secret-key}") String secretKey, UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
@@ -79,8 +88,27 @@ public class JwtProvider {
         }
     }
 
-    public Long getUserIdFromToken(String token) {
+
+    public Long getUserIdParsingFromToken(String token) {
         return Long.parseLong(extractSubject(token)); // subject를 userId로 변환
     }
+
+    public String getUserIdFromToken(String token){
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public Authentication getAuthentication(String token){
+        UserDetails userDetails =
+                (UserDetails)
+                        userDetailsService.loadUserByUsername(getUserIdFromToken(token));
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, token, userDetails.getAuthorities());
+    }
+
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -195,7 +195,7 @@ public class AuthService {
 
     // JWT 토큰 관련 처리
     public TokenDTO recreateAccessToken(String refreshToken) {
-        Long userId = jwtProvider.getUserIdFromToken(refreshToken);
+        Long userId = jwtProvider.getUserIdParsingFromToken(refreshToken);
         tokenAuthService.validateRefreshToken(userId, refreshToken);
 
         User user = getUserById(userId);

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/CustomUserDetailsService.java
@@ -19,9 +19,11 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        Long id = Long.valueOf(userId);
+        return userRepository.findById(id)
                 .map(member -> new User(member.getEmail(), "", Collections.emptyList()))
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
     }
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/config/WebSocketConfig.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/config/WebSocketConfig.java
@@ -1,9 +1,12 @@
 package chungbazi.chungbazi_be.global.config;
 
+import chungbazi.chungbazi_be.global.infra.StompAuthChannelInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -13,6 +16,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
     @Value("${spring.rabbitmq.host}")
     private String rabbitHost;
 
@@ -44,6 +48,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*");
                 //.withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/infra/StompAuthChannelInterceptor.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/infra/StompAuthChannelInterceptor.java
@@ -21,7 +21,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             String token = accessor.getFirstNativeHeader("Authorization");
-            if (token != null && token.startsWith("Bearer ")) {
+            if (token == null || !token.startsWith("Bearer ")) {
                 throw new IllegalArgumentException("Authorization header missing or invalid");
             }
             token = token.substring(7);

--- a/src/main/java/chungbazi/chungbazi_be/global/infra/StompAuthChannelInterceptor.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/infra/StompAuthChannelInterceptor.java
@@ -1,0 +1,36 @@
+package chungbazi.chungbazi_be.global.infra;
+
+import chungbazi.chungbazi_be.domain.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String token = accessor.getFirstNativeHeader("Authorization");
+            if (token != null && token.startsWith("Bearer ")) {
+                throw new IllegalArgumentException("Authorization header missing or invalid");
+            }
+            token = token.substring(7);
+            jwtProvider.validateToken(token);
+            Authentication auth = jwtProvider.getAuthentication(token);
+            accessor.setUser(auth);
+
+        }
+
+        return message;
+    }
+}


### PR DESCRIPTION
## 개요

🚨 문제 상황
- 현재 채팅 기능을 구현하는 과정에서 WebSocket 연결이 정상적으로 열리지만, 메시지 전송 시 getAuthenticatedUser() 호출 시 인증 정보가 없어서 예외가 발생하는 문제 발생
-> 로그를 확인해보니 /api/ws 요청이 HTTP 상태 403으로 응답되고 있으며, WebSocket 연결에 대한 업그레이드가 제대로 이루어지지 않으며 클라이언트에서 Authorization: Bearer <토큰> 및 userId 헤더를 포함해서 요청하고 있음에도, 서버 측에서 Principal이 설정되지 않아 이후 처리가 실패하고 있었다.

=> WebSocketConfig에 인증 처리 인터셉터(ChannelInterceptor)를 추가하여 STOMP CONNECT 프레임에서 JWT 토큰을 검증하고 Principal을 설정하고, configureClientInboundChannel 메서드를 오버라이딩해서 해당 인터셉터를 등록했다.
<br/>

## ✅ 작업 내용

- [x] ChannelInterceptor 오버라이딩
- [x] auth 수정

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * WebSocket 연결 시 토큰 기반 인증 지원 추가 (STOMP CONNECT 단계에서 인증 수행)
  * STOMP 메시지 흐름에 인증 인터셉터 도입으로 실시간 연결 보안 강화
  * 인증 처리 방식이 이메일 대신 사용자 ID 기반으로 동작하도록 변경

* **개선사항**
  * 실시간 통신 보안 및 인증 신뢰성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->