### PR TITLE
[fix] 프로필 조회 시, 로그인 타입 반환

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -85,8 +85,6 @@ jobs:
             fi
             
             sudo docker image prune -a --filter "until=72h" -f
-            sudo docker container prune --filter "until=72h" -f
-            sudo docker network prune --filter "until=72h" -f
       # jar 파일명 확인
       - name: Show built files
         run: |

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -32,7 +32,6 @@ import java.security.PublicKey;
 @RequiredArgsConstructor
 public class AuthService {
 
-
     private final TokenGenerator tokenGenerator;
     private final TokenAuthService tokenAuthService;
     private final FCMService fcmService;
@@ -266,7 +265,6 @@ public class AuthService {
         user.updatePassword(encodedPassword);
         userRepository.save(user);
     }
-
 
     public void resetPasswordWithEmailAndCode(ResetPasswordNoAuthRequestDTO request) {
         mailService.verifiedCode(request.getEmail(),request.getAuthCode());

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -63,5 +63,4 @@ public class NotificationController {
         return ApiResponse.onSuccess(response);
     }
 
-
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/converter/UserConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/converter/UserConverter.java
@@ -9,6 +9,7 @@ public class UserConverter {
                 .userId(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
+                .oAuthProvider(user.getOAuthProvider().getDescription())
                 .characterImg(user.getCharacterImg())
                 .build();
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/response/UserResponseDTO.java
@@ -14,6 +14,7 @@ public class UserResponseDTO {
         Long userId;
         String name;
         String email;
+        String oAuthProvider;
         RewardLevel characterImg;
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/enums/OAuthProvider.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/enums/OAuthProvider.java
@@ -1,5 +1,17 @@
 package chungbazi.chungbazi_be.domain.user.entity.enums;
 
 public enum OAuthProvider {
-    APPLE, KAKAO, LOCAL
+    APPLE("애플"),
+    KAKAO("카카오"),
+    LOCAL("일반");
+
+    public String description;
+
+    OAuthProvider(String description){
+        this.description = description;
+    }
+
+    public String getDescription(){
+        return description;
+    }
 }


### PR DESCRIPTION
## 개요

프론트 측에서 프로필 조회 시, 로그인 타입이 필요하다고 하여, 이를 응답에 추가하였습니다.
<img width="1082" height="306" alt="image" src="https://github.com/user-attachments/assets/5ee46e00-3c9a-4546-9584-e92b88cf654a" />


<br/>

## ✅ 작업 내용

- 프로필 조회 시, 로그인 타입 반환

<br/>

### 📝 논의사항

필드 하나만 추가한거라, 따로 특이사항은 없을 거 같습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 응답에 OAuth 제공자 정보가 한국어 설명(애플, 카카오, 일반)과 함께 포함됩니다.

* **Chores**
  * 코드 포맷팅 정리로 불필요한 공백 제거.
  * CI 설정 정리로 일부 불필요한 정리 명령이 제거되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->