### PR TITLE
[fix] 알림 도메인 관련 QA 반영

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -103,7 +103,7 @@ public class AuthService {
         boolean isFirst = determineIsFirst(user);
         TokenDTO tokenDTO = tokenGenerator.generate(user.getId(), user.getName(), isFirst);
         tokenAuthService.saveRefreshToken(user.getId(), tokenDTO.getRefreshToken(), tokenDTO.getRefreshExp());
-        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
+        fcmTokenService.registerOrUpdateToken(user, request.getFcmToken());
         return tokenDTO;
     }
 
@@ -113,7 +113,7 @@ public class AuthService {
         boolean isFirst = determineIsFirst(user);
         TokenDTO tokenDTO = tokenGenerator.generate(user.getId(), user.getName(), isFirst);
         tokenAuthService.saveRefreshToken(user.getId(), tokenDTO.getRefreshToken(), tokenDTO.getRefreshExp());
-        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
+        fcmTokenService.registerOrUpdateToken(user, request.getFcmToken());
         return tokenDTO;
     }
 
@@ -163,14 +163,14 @@ public class AuthService {
                 })
                 .orElseGet(() -> createUserForAppleLogin(email, appleUserId, oAuthProvider));
 
-        // 6. FCM 토큰 저장
-        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
 
         // 7. JWT 토큰 발급 및 저장
         boolean isFirst = determineIsFirst(user);
         TokenDTO tokenDTO = tokenGenerator.generate(user.getId(), user.getName(), isFirst);
         tokenAuthService.saveRefreshToken(user.getId(), tokenDTO.getRefreshToken(), tokenDTO.getRefreshExp());
-        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
+
+        //fcm 토큰 저장
+        fcmTokenService.registerOrUpdateToken(user, request.getFcmToken());
 
         return tokenDTO;
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -12,7 +12,7 @@ import chungbazi.chungbazi_be.domain.auth.dto.TokenResponseDTO;
 import chungbazi.chungbazi_be.domain.auth.jwt.JwtProvider;
 import chungbazi.chungbazi_be.domain.auth.jwt.SecurityUtils;
 import chungbazi.chungbazi_be.domain.auth.jwt.TokenGenerator;
-import chungbazi.chungbazi_be.domain.notification.service.FCMService;
+import chungbazi.chungbazi_be.domain.notification.service.FcmTokenService;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.entity.enums.OAuthProvider;
 import chungbazi.chungbazi_be.domain.user.repository.UserRepository;
@@ -34,7 +34,7 @@ public class AuthService {
 
     private final TokenGenerator tokenGenerator;
     private final TokenAuthService tokenAuthService;
-    private final FCMService fcmService;
+    private final FcmTokenService fcmTokenService;
     private final AuthConverter authConverter;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
@@ -61,6 +61,9 @@ public class AuthService {
                 .name("닉네임을 등록해주세요.")
                 .oAuthProvider(OAuthProvider.LOCAL)
                 .build();
+
+        user.createNotificationSetting();
+
         userRepository.save(user);
     }
 
@@ -100,7 +103,7 @@ public class AuthService {
         boolean isFirst = determineIsFirst(user);
         TokenDTO tokenDTO = tokenGenerator.generate(user.getId(), user.getName(), isFirst);
         tokenAuthService.saveRefreshToken(user.getId(), tokenDTO.getRefreshToken(), tokenDTO.getRefreshExp());
-        fcmService.saveFcmToken(user.getId(), request.getFcmToken());
+        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
         return tokenDTO;
     }
 
@@ -110,7 +113,7 @@ public class AuthService {
         boolean isFirst = determineIsFirst(user);
         TokenDTO tokenDTO = tokenGenerator.generate(user.getId(), user.getName(), isFirst);
         tokenAuthService.saveRefreshToken(user.getId(), tokenDTO.getRefreshToken(), tokenDTO.getRefreshExp());
-        fcmService.saveFcmToken(user.getId(), request.getFcmToken());
+        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
         return tokenDTO;
     }
 
@@ -133,6 +136,9 @@ public class AuthService {
                 .password("")
                 .oAuthProvider(oAuthProvider)
                 .build();
+
+        user.createNotificationSetting();
+
         return userRepository.save(user);
     }
 
@@ -158,13 +164,13 @@ public class AuthService {
                 .orElseGet(() -> createUserForAppleLogin(email, appleUserId, oAuthProvider));
 
         // 6. FCM 토큰 저장
-        fcmService.saveFcmToken(user.getId(), request.getFcmToken());
+        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
 
         // 7. JWT 토큰 발급 및 저장
         boolean isFirst = determineIsFirst(user);
         TokenDTO tokenDTO = tokenGenerator.generate(user.getId(), user.getName(), isFirst);
         tokenAuthService.saveRefreshToken(user.getId(), tokenDTO.getRefreshToken(), tokenDTO.getRefreshExp());
-        fcmService.saveFcmToken(user.getId(), request.getFcmToken());
+        fcmTokenService.saveFcmToken(user.getId(), request.getFcmToken());
 
         return tokenDTO;
     }
@@ -188,6 +194,9 @@ public class AuthService {
                 .password("")
                 .oAuthProvider(oAuthProvider)
                 .build();
+
+        user.createNotificationSetting();
+
         return userRepository.save(user);
     }
 
@@ -223,7 +232,7 @@ public class AuthService {
         tokenAuthService.addToBlackList(token, "delete-account", 3600L);
         tokenAuthService.deleteRefreshToken(userId);
         deleteUser(userId);
-        fcmService.deleteToken(userId);
+        fcmTokenService.deleteToken(userId);
     }
 
     // 응답

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -5,8 +5,11 @@ import chungbazi.chungbazi_be.domain.notification.dto.response.NotificationRespo
 import chungbazi.chungbazi_be.domain.notification.dto.request.NotificationSettingRequestDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.response.NotificationSettingResponseDTO;
 import chungbazi.chungbazi_be.domain.notification.entity.enums.NotificationType;
+import chungbazi.chungbazi_be.domain.notification.service.FcmTokenService;
 import chungbazi.chungbazi_be.domain.notification.service.NotificationService;
 import chungbazi.chungbazi_be.domain.notification.service.NotificationSettingService;
+import chungbazi.chungbazi_be.domain.user.entity.User;
+import chungbazi.chungbazi_be.domain.user.support.UserHelper;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
 import chungbazi.chungbazi_be.global.utils.PaginationResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,14 +24,16 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
     private final NotificationService notificationService;
     private final NotificationSettingService notificationSettingService;
+    private final FcmTokenService fcmTokenService;
+    private final UserHelper userHelper;
 
-    @PostMapping("/notifications/fcm-token")
-    @Operation(summary = "FCM 토큰 저장 API", description = "유저가 FCM 토큰을 저장할 때 사용하는 API입니다.")
-    public ApiResponse<String> saveFcmToken(@RequestBody FcmTokenRequestDTO requestDTO){
+    @PostMapping()
+    @Operation(summary = "FCM 토큰 저장 API", description = "FCM 토큰을 저장하는 API입니다.")
+    public ApiResponse<String> saveFcmToken(@RequestBody FcmTokenRequestDTO requestDTO) {
+        User user = userHelper.getAuthenticatedUser();
+        fcmTokenService.registerOrUpdateToken(user, requestDTO.fcmToken());
 
-        notificationService.saveFcmToken(requestDTO.fcmToken());
-
-        return ApiResponse.onSuccess("FCM 토큰이 저장되었습니다.");
+        return ApiResponse.onSuccess("FCM 토큰 저장이 완료되었습니다.");
     }
 
     @PatchMapping("/{notificationId}/read")

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package chungbazi.chungbazi_be.domain.notification.controller;
 
+import chungbazi.chungbazi_be.domain.notification.dto.request.FcmTokenRequestDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.response.NotificationResponseDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.request.NotificationSettingRequestDTO;
 import chungbazi.chungbazi_be.domain.notification.dto.response.NotificationSettingResponseDTO;
@@ -20,6 +21,15 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
     private final NotificationService notificationService;
     private final NotificationSettingService notificationSettingService;
+
+    @PostMapping("/notifications/fcm-token")
+    @Operation(summary = "FCM 토큰 저장 API", description = "유저가 FCM 토큰을 저장할 때 사용하는 API입니다.")
+    public ApiResponse<String> saveFcmToken(@RequestBody FcmTokenRequestDTO requestDTO){
+
+        notificationService.saveFcmToken(requestDTO.fcmToken());
+
+        return ApiResponse.onSuccess("FCM 토큰이 저장되었습니다.");
+    }
 
     @PatchMapping("/{notificationId}/read")
     @Operation(summary = "특정 알림 읽음 상태 변경 API")

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/controller/NotificationController.java
@@ -14,6 +14,7 @@ import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
 import chungbazi.chungbazi_be.global.utils.PaginationResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,7 +30,7 @@ public class NotificationController {
 
     @PostMapping()
     @Operation(summary = "FCM 토큰 저장 API", description = "FCM 토큰을 저장하는 API입니다.")
-    public ApiResponse<String> saveFcmToken(@RequestBody FcmTokenRequestDTO requestDTO) {
+    public ApiResponse<String> saveFcmToken(@RequestBody @Valid FcmTokenRequestDTO requestDTO) {
         User user = userHelper.getAuthenticatedUser();
         fcmTokenService.registerOrUpdateToken(user, requestDTO.fcmToken());
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/request/FcmTokenRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/request/FcmTokenRequestDTO.java
@@ -1,0 +1,6 @@
+package chungbazi.chungbazi_be.domain.notification.dto.request;
+
+public record FcmTokenRequestDTO(
+        String fcmToken
+) {
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/request/FcmTokenRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/dto/request/FcmTokenRequestDTO.java
@@ -1,6 +1,9 @@
 package chungbazi.chungbazi_be.domain.notification.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record FcmTokenRequestDTO(
+        @NotBlank
         String fcmToken
 ) {
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/FcmToken.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/FcmToken.java
@@ -33,4 +33,9 @@ public class FcmToken extends BaseTimeEntity {
     public boolean isExpired() {
         return lastUsedAt.isBefore(LocalDateTime.now().minusDays(30));
     }
+
+    public void updateToken(String newToken) {
+        this.lastUsedAt = LocalDateTime.now();
+        this.token = newToken;
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/FcmToken.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/entity/FcmToken.java
@@ -1,0 +1,36 @@
+package chungbazi.chungbazi_be.domain.notification.entity;
+
+import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String token;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, columnDefinition = "timestamp")
+    private LocalDateTime lastUsedAt;
+
+    public void updateLastUsedAt() {
+        this.lastUsedAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired() {
+        return lastUsedAt.isBefore(LocalDateTime.now().minusDays(30));
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/repository/FcmTokenRepository.java
@@ -1,0 +1,13 @@
+package chungbazi.chungbazi_be.domain.notification.repository;
+
+import chungbazi.chungbazi_be.domain.notification.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    Optional<FcmToken> findByUserId(Long userId);
+
+    Optional<FcmToken> findByToken(String token);
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmService.java
@@ -1,0 +1,41 @@
+package chungbazi.chungbazi_be.domain.notification.service;
+
+import chungbazi.chungbazi_be.domain.notification.dto.internal.FcmPushData;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    //fcm한테 알림 요청
+    public void pushFCMNotification(String fcmToken, FcmPushData fcmPushData) {
+        try {
+            Notification notification =Notification.builder()
+                    .setTitle("새로운 알림이 도착했습니다.")
+                    .setBody(fcmPushData.message())
+                    .build();
+
+            Map<String, String> data = new HashMap<>();
+            data.put("targetId", fcmPushData.targetId().toString());
+            data.put("notificationType", fcmPushData.type().toString());
+
+            Message firebaseMessage = Message.builder()
+                    .setToken(fcmToken)
+                    .setNotification(notification)
+                    .putAllData(data)
+                    .build();
+
+            String response = FirebaseMessaging.getInstance().send(firebaseMessage);
+        }catch(FirebaseMessagingException e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmTokenCacheService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmTokenCacheService.java
@@ -1,0 +1,81 @@
+package chungbazi.chungbazi_be.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmTokenCacheService {
+
+    private static final String FCM_TOKEN_PREFIX = "fcm:token:";
+    private static final Duration TOKEN_TTL = Duration.ofDays(30);
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void cacheToken(Long userId, String token) {
+        try {
+            String key = FCM_TOKEN_PREFIX + userId;
+            redisTemplate.opsForValue().set(key, token, TOKEN_TTL);
+
+            log.debug("FCM 토큰 캐시 저장 완료: userId={}, token={}", userId, maskToken(token));
+        } catch (Exception e) {
+            log.error("FCM 토큰 캐시 저장 실패: userId={}", userId, e);
+        }
+    }
+
+    public void refreshTokenTtl(Long userId) {
+        try {
+            String key = FCM_TOKEN_PREFIX + userId;
+            redisTemplate.expire(key, TOKEN_TTL);
+
+            log.debug("FCM 토큰 TTL 갱신 완료");
+        } catch (Exception e) {
+            log.error("FCM 토큰 TTL 갱신 실패", e);
+        }
+    }
+
+    public String getTokenByUserId(Long userId) {
+        try {
+            String key = FCM_TOKEN_PREFIX + userId;
+            String token = redisTemplate.opsForValue().get(key);
+            return token;
+        } catch (Exception e) {
+            log.error("FCM 토큰 캐시 조회 실패", e);
+            return null;
+        }
+    }
+
+    public void deleteToken(Long userId) {
+        try {
+            String key = FCM_TOKEN_PREFIX + userId;
+
+            redisTemplate.delete(key);
+
+            log.debug("FCM 토큰 캐시 삭제 완료");
+        } catch (Exception e) {
+            log.error("FCM 토큰 캐시 삭제 실패", e);
+        }
+    }
+
+    public boolean existsToken(Long userId) {
+        try {
+            String key = FCM_TOKEN_PREFIX + userId;
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+        } catch (Exception e) {
+            log.error("FCM 토큰 존재 여부 확인 실패", e);
+            return false;
+        }
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.length() < 10) {
+            return "***";
+        }
+        return token.substring(0, 10) + "...";
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmTokenService.java
@@ -16,19 +16,25 @@ import java.util.Map;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class FCMService {
+public class FcmTokenService {
     private final RedisTemplate<String, String> redisTemplate;
 
+    private static final String KEY_PREFIX = "fcm_token:";
+    private static final long TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7;
+
     public void saveFcmToken(Long userId, String fcmToken) {
-        redisTemplate.opsForValue().set("_"+String.valueOf(userId), fcmToken);
+        String key = KEY_PREFIX + userId;
+        redisTemplate.opsForValue().set("_"+key, fcmToken, TOKEN_EXPIRATION_TIME);
     }
 
     public String getToken(Long userId){
-        return redisTemplate.opsForValue().get("_"+String.valueOf(userId));
+        String key = KEY_PREFIX + userId;
+        return redisTemplate.opsForValue().get("_"+key);
     }
 
     public void deleteToken(Long userId){
-        redisTemplate.delete(String.valueOf("_"+userId));
+        String key = KEY_PREFIX + userId;
+        redisTemplate.delete(key);
     }
 
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/FcmTokenService.java
@@ -1,65 +1,93 @@
 package chungbazi.chungbazi_be.domain.notification.service;
 
-import chungbazi.chungbazi_be.domain.notification.dto.internal.FcmPushData;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import chungbazi.chungbazi_be.domain.notification.entity.FcmToken;
+import chungbazi.chungbazi_be.domain.notification.repository.FcmTokenRepository;
+import chungbazi.chungbazi_be.domain.user.entity.User;
+import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
+import chungbazi.chungbazi_be.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class FcmTokenService {
-    private final RedisTemplate<String, String> redisTemplate;
 
-    private static final String KEY_PREFIX = "fcm_token:";
-    private static final long TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenCacheService cacheService;
 
-    public void saveFcmToken(Long userId, String fcmToken) {
-        String key = KEY_PREFIX + userId;
-        redisTemplate.opsForValue().set("_"+key, fcmToken, TOKEN_EXPIRATION_TIME);
-    }
+    @Transactional
+    public void registerOrUpdateToken(User user, String token) {
+        FcmToken fcmToken = getByUserId(user.getId())
+                .orElse(null);
 
-    public String getToken(Long userId){
-        String key = KEY_PREFIX + userId;
-        return redisTemplate.opsForValue().get("_"+key);
-    }
-
-    public void deleteToken(Long userId){
-        String key = KEY_PREFIX + userId;
-        redisTemplate.delete(key);
-    }
-
-
-    //fcm한테 알림 요청
-    public void pushFCMNotification(String fcmToken, FcmPushData fcmPushData) {
-        try {
-            Notification notification =Notification.builder()
-                            .setTitle("새로운 알림이 도착했습니다.")
-                            .setBody(fcmPushData.message())
-                            .build();
-
-            Map<String, String> data = new HashMap<>();
-            data.put("targetId", fcmPushData.targetId().toString());
-            data.put("notificationType", fcmPushData.type().toString());
-
-            Message firebaseMessage = Message.builder()
-                    .setToken(fcmToken)
-                    .setNotification(notification)
-                    .putAllData(data)
+        if (fcmToken != null) {
+            updateTokenUsage(fcmToken);
+        } else {
+            fcmToken = FcmToken.builder()
+                    .userId(user.getId())
+                    .token(token)
+                    .lastUsedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                     .build();
-
-            String response = FirebaseMessaging.getInstance().send(firebaseMessage);
-        }catch(FirebaseMessagingException e){
-            e.printStackTrace();
         }
+
+        fcmTokenRepository.save(fcmToken);
+        cacheService.cacheToken(user.getId(), token);
+
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FcmToken> getByUserId(Long userId) {
+        return fcmTokenRepository.findByUserId(userId);
+    }
+
+    //토큰 갱신
+    @Transactional
+    public void updateTokenUsage(FcmToken fcmToken) {
+
+        fcmToken.updateLastUsedAt();
+        fcmTokenRepository.save(fcmToken);
+
+        // Redis TTL 갱신
+        cacheService.refreshTokenTtl(fcmToken.getUserId());
+
+    }
+
+    @Transactional
+    public void deleteToken(Long userId) {
+
+        FcmToken fcmToken = fcmTokenRepository.findByUserId(userId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_FCM_TOKEN));
+
+        // DB에서 삭제
+        fcmTokenRepository.delete(fcmToken);
+
+        //redis 캐시에서 삭제
+        cacheService.deleteToken(fcmToken.getUserId());
+
+    }
+
+    @Transactional
+    public String getFcmToken(Long userId){
+
+        //캐시에 fcm 토큰이 존재할 경우
+        if (cacheService.existsToken(userId)) {
+            return cacheService.getTokenByUserId(userId);
+        } else {
+            FcmToken fcmToken = getByUserId(userId)
+                    .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_FCM_TOKEN));
+
+            cacheService.cacheToken(userId, fcmToken.getToken());
+            return fcmToken.getToken();
+        }
+
     }
 
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -25,7 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationService {
     private final NotificationRepository notificationRepository;
-    private final FCMService fcmService;
+    private final FcmTokenService fcmTokenService;
     private final UserHelper userHelper;
 
     //알람 읽음 처리
@@ -68,11 +68,11 @@ public class NotificationService {
         notificationRepository.save(notification);
 
         //FCM 푸시 전송
-        String fcmToken = fcmService.getToken(request.getUser().getId());
+        String fcmToken = fcmTokenService.getToken(request.getUser().getId());
 
         if (fcmToken != null) {
             FcmPushData data = FcmPushData.from(notification);
-            fcmService.pushFCMNotification(fcmToken,data);
+            fcmTokenService.pushFCMNotification(fcmToken,data);
         }
     }
 
@@ -84,4 +84,7 @@ public class NotificationService {
                 .anyMatch(notification -> !notification.isRead());
     }
 
+    public void saveFcmToken(String fcmToken) {
+        
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationService.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final FcmTokenService fcmTokenService;
+    private final FcmService fcmService;
     private final UserHelper userHelper;
 
     //알람 읽음 처리
@@ -68,11 +69,11 @@ public class NotificationService {
         notificationRepository.save(notification);
 
         //FCM 푸시 전송
-        String fcmToken = fcmTokenService.getToken(request.getUser().getId());
+        String fcmToken = fcmTokenService.getFcmToken(request.getUser().getId());
 
         if (fcmToken != null) {
             FcmPushData data = FcmPushData.from(notification);
-            fcmTokenService.pushFCMNotification(fcmToken,data);
+            fcmService.pushFCMNotification(fcmToken,data);
         }
     }
 
@@ -84,7 +85,4 @@ public class NotificationService {
                 .anyMatch(notification -> !notification.isRead());
     }
 
-    public void saveFcmToken(String fcmToken) {
-        
-    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationSettingService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class NotificationSettingService {

--- a/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/notification/service/NotificationSettingService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class NotificationSettingService {
@@ -22,7 +24,15 @@ public class NotificationSettingService {
     public NotificationSettingResponseDTO.settingResDto setNotificationSetting(NotificationSettingRequestDTO dto){
         User user=userHelper.getAuthenticatedUser();
 
-        NotificationSetting setting=user.getNotificationSetting();
+        NotificationSetting setting= user.getNotificationSetting();
+
+        if (setting == null) {
+            NotificationSetting notificationSetting = NotificationSetting.builder()
+                    .user(user)
+                    .build();
+
+            setting = notificationSettingRepository.save(notificationSetting);
+        }
 
         setting.updateNotificationSetting(dto.isPolicyAlarm(), dto.isCommunityAlarm(), dto.isRewardAlarm(), dto.isNoticeAlarm());
 
@@ -33,10 +43,18 @@ public class NotificationSettingService {
     }
 
     //알림 수신 설정 조회
-    @Transactional(readOnly = true)
+    @Transactional
     public NotificationSettingResponseDTO.settingResDto getNotificationSetting(){
         User user=userHelper.getAuthenticatedUser();
         NotificationSetting setting=user.getNotificationSetting();
+
+        if (setting == null) {
+            NotificationSetting notificationSetting = NotificationSetting.builder()
+                    .user(user)
+                    .build();
+
+            setting = notificationSettingRepository.save(notificationSetting);
+        }
 
         return NotificationConverter.toSettingResDto(setting);
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
@@ -161,4 +161,10 @@ public class User {
 
     // 알람 관련
     public void updateNotificationSetting(NotificationSetting notificationSetting) {this.notificationSetting = notificationSetting;}
+
+    public void createNotificationSetting() {
+        this.notificationSetting = NotificationSetting.builder()
+                .user(this)
+                .build();
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -57,6 +57,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CHAT_ALARM_CHAT_NULL(HttpStatus.BAD_REQUEST, "NOTIFICATION003", "Chat 알림에서 chat이 null입니다."),
     POLICY_ALARM_CHAT_NULL(HttpStatus.BAD_REQUEST, "NOTIFICATION004", "Chat 알림에서 chat이 null입니다."),
     INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "NOTIFICATION005", "알림 타입이 존재하지 않습니다."),
+    NOT_FOUND_FCM_TOKEN(HttpStatus.NOT_FOUND, "FCMTOKEN404", "해당 fcm 토큰이 존재하지 않습니다."),
 
     //인증 관련 에러
     MALFORMED_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4012", "잘못된 형식의 토큰입니다."),


### PR DESCRIPTION
## 연관 이슈

close #180 

<br/>

## 개요

알림 도메인 관련 QA 반영했습니다.

<br/>

## ✅ 작업 내용

- 알림 설정 default 생성
    우선 현재 서비스 내에 알림 설정이 없을 수도 있으므로 알림 설정 조회 시 엔티티 생기도록 로직 추가하였습니다.
    이 부분은 추후에 안정화되고나서는 삭제하겠습니다!
<img width="643" height="199" alt="image" src="https://github.com/user-attachments/assets/85411f2e-574f-4afb-8122-e439313270d1" />
회원가입 시, notification_setting 생성되는 것 확인 완료

- FCM token 발급 로직 수정
    fcm token 자체는 잘 받아오고있으나, redis에만 저장하고 프론트 측에서 로그인 API를 불러오지 않을 때가 있어 따로 fcm token을 저장하는 로직을 추가했습니다.
    추가로, FCM token 엔티티를 만들어서 redis를 껐다 킬 경우에도 DB에서 가져올 수 있도록 구현했습니다.
<img width="513" height="109" alt="image" src="https://github.com/user-attachments/assets/b27d7886-caf8-48bf-a610-08cdde2e2c51" />
FCM token 저장되는 것 확인 완료

<br/>

### 📝 논의사항

FCM token은 주로 2주이상 들어오지 않을 경우에는 유효성이 없다고 보면서 삭제하는 로직을 권장하고 있다고 합니다.
그러나 저희 서비스에서는 한 달 정도는 유지하는 게 좋을 거 같아, TTL을 30일로 설정했는데, 정빈님은 어떻게 생각하시는지 궁금합니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림 토큰 저장용 API 엔드포인트 추가
  * 푸시 토큰을 DB와 캐시(만료관리)로 안정적으로 관리하는 기능 추가

* **개선 사항**
  * 사용자 가입 및 로그인 시 알림 설정을 자동으로 초기화하도록 개선
  * 토큰 사용 시간 및 만료 추적으로 푸시 신뢰성 향상

* **오류 처리**
  * 존재하지 않는 FCM 토큰에 대한 명확한 오류 응답 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->