### PR TITLE
[feat] 사용자 정보 조회 API

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package chungbazi.chungbazi_be.domain.user.controller;
 
 import chungbazi.chungbazi_be.domain.user.dto.request.UserRequestDTO;
+import chungbazi.chungbazi_be.domain.user.dto.response.UserInformationResponse;
+import chungbazi.chungbazi_be.domain.user.dto.response.UserInterestListResponse;
 import chungbazi.chungbazi_be.domain.user.dto.response.UserResponseDTO;
 import chungbazi.chungbazi_be.domain.user.service.UserService;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
@@ -55,6 +57,22 @@ public class UserController {
     public ApiResponse<String> updateUserInfo(@RequestBody UserRequestDTO.UpdateDto updateDto) {
         userService.updateUserInfo(updateDto);
         return ApiResponse.onSuccess("User information updated successfully.");
+    }
+
+    @GetMapping("/information")
+    @Operation(summary = "사용자 정보 조회 API", description = "사용자 정보(지역, 취업상태, 소득, 추가사항, 관심사, 학력)를 조회하는 API입니다.")
+    public ApiResponse<UserInformationResponse> getUserInfo(){
+        UserInformationResponse response = userService.getUserInformation();
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/interests")
+    @Operation(summary = "사용자의 관심사 조회 API", description = "사용자의 관심사를 조회하는 API입니다.")
+    public ApiResponse<UserInterestListResponse> getUserInterestList(){
+        UserInterestListResponse response = userService.getUserInterest();
+
+        return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/email/exists")

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/response/UserInformationResponse.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/response/UserInformationResponse.java
@@ -1,0 +1,34 @@
+package chungbazi.chungbazi_be.domain.user.dto.response;
+
+import chungbazi.chungbazi_be.domain.user.entity.User;
+import chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record UserInformationResponse(
+    String employment,
+    String education,
+    String income,
+    List<String> interests,
+    List<String> additions
+) {
+    public static UserInformationResponse from(User user) {
+        List<String> interests = user.getUserInterestList().stream()
+                .map(userInterest -> userInterest.getInterest().getName())
+                .collect(Collectors.toList());
+
+        List<String> additions = user.getUserAdditionList().stream()
+                .map(userAddition -> userAddition.getAddition().getName())
+                .collect(Collectors.toList());
+
+        return new UserInformationResponse(
+                user.getEmployment().toJson(),
+                user.getEducation().toJson(),
+                user.getIncome().toJson(),
+                interests,
+                additions
+        );
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/response/UserInterestListResponse.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/response/UserInterestListResponse.java
@@ -1,0 +1,18 @@
+package chungbazi.chungbazi_be.domain.user.dto.response;
+
+import chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record UserInterestListResponse(
+        List<String> userInterestList
+) {
+    public static UserInterestListResponse from(List<UserInterest> interests) {
+        List<String> userInterests = interests.stream()
+                .map(userInterest -> userInterest.getInterest().getName())
+                .collect(Collectors.toList());
+
+        return new UserInterestListResponse(userInterests);
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserInterestRepository.java
@@ -3,9 +3,18 @@ package chungbazi.chungbazi_be.domain.user.repository;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
     void deleteByUser(User user);
+
+    @Query("SELECT ui FROM UserInterest ui " +
+            "LEFT JOIN FETCH ui.interest " +
+            "WHERE ui.user = :user ")
+    List<UserInterest> findAllByUser(@Param("user") User user);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -21,4 +21,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("UPDATE User u SET u.name = '(알 수 없음)', u.email = CONCAT('deleted_', u.id, '@chungbazi.com') WHERE u.id = :userId")
     void anonymizeUser(@Param("userId") Long userId);
 
+    @Query("SELECT DISTINCT u FROM User u " +
+            "LEFT JOIN FETCH u.userAdditionList ua " +
+            "LEFT JOIN FETCH ua.addition " +
+            "LEFT JOIN FETCH u.userInterestList ui " +
+            "LEFT JOIN FETCH ui.interest " +
+            "WHERE u.id = :userId")
+    Optional<User> findByIdWithAdditionsAndInterests(Long userId);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -1,10 +1,10 @@
 package chungbazi.chungbazi_be.domain.user.repository;
 
 import chungbazi.chungbazi_be.domain.user.entity.User;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/repository/UserRepository.java
@@ -24,8 +24,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT DISTINCT u FROM User u " +
             "LEFT JOIN FETCH u.userAdditionList ua " +
             "LEFT JOIN FETCH ua.addition " +
+            "WHERE u.id = :userId")
+    Optional<User> findByIdWithAdditions(@Param("userId") Long userId);
+
+    @Query("SELECT DISTINCT u FROM User u " +
             "LEFT JOIN FETCH u.userInterestList ui " +
             "LEFT JOIN FETCH ui.interest " +
             "WHERE u.id = :userId")
-    Optional<User> findByIdWithAdditionsAndInterests(Long userId);
+    Optional<User> findByIdWithInterests(@Param("userId") Long userId);
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -138,7 +138,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserInformationResponse getUserInformation() {
-        User user = userHelper.getAuthenticatedUser();
+        User user = userHelper.getUserWithInformation();
 
         validateOnboardingCompleted(user);
 
@@ -153,6 +153,7 @@ public class UserService {
 
         return UserInterestListResponse.from(interests);
     }
+
 
     private void validateOnboardingCompleted(User user) {
         if (user.getEducation() == null ||

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/service/UserService.java
@@ -5,6 +5,8 @@ import chungbazi.chungbazi_be.domain.community.repository.CommentRepository;
 import chungbazi.chungbazi_be.domain.community.repository.PostRepository;
 import chungbazi.chungbazi_be.domain.user.converter.UserConverter;
 import chungbazi.chungbazi_be.domain.user.dto.request.UserRequestDTO;
+import chungbazi.chungbazi_be.domain.user.dto.response.UserInformationResponse;
+import chungbazi.chungbazi_be.domain.user.dto.response.UserInterestListResponse;
 import chungbazi.chungbazi_be.domain.user.dto.response.UserResponseDTO;
 import chungbazi.chungbazi_be.domain.user.entity.Addition;
 import chungbazi.chungbazi_be.domain.user.entity.Interest;
@@ -14,6 +16,8 @@ import chungbazi.chungbazi_be.domain.user.entity.mapping.UserInterest;
 import chungbazi.chungbazi_be.domain.user.repository.*;
 import chungbazi.chungbazi_be.domain.user.support.UserHelper;
 import chungbazi.chungbazi_be.domain.user.validator.UserValidator;
+import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
+import chungbazi.chungbazi_be.global.apiPayload.exception.GeneralException;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -131,4 +135,31 @@ public class UserService {
             userInterestRepository.save(UserInterest.builder().user(user).interest(interest).build());
         }
     }
+
+    @Transactional(readOnly = true)
+    public UserInformationResponse getUserInformation() {
+        User user = userHelper.getAuthenticatedUser();
+
+        validateOnboardingCompleted(user);
+
+        return UserInformationResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UserInterestListResponse getUserInterest() {
+        User user = userHelper.getAuthenticatedUser();
+
+        List<UserInterest> interests = userInterestRepository.findAllByUser(user);
+
+        return UserInterestListResponse.from(interests);
+    }
+
+    private void validateOnboardingCompleted(User user) {
+        if (user.getEducation() == null ||
+                user.getEmployment() == null ||
+                user.getIncome() == null) {
+            throw new GeneralException(ErrorStatus.ONBOARDING_NOT_COMPLETED);
+        }
+    }
+
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserHelper.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserHelper.java
@@ -18,4 +18,10 @@ public class UserHelper {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
     }
+
+    public User getUserWithInformation(){
+        Long userId = SecurityUtils.getUserId();
+        return userRepository.findByIdWithAdditionsAndInterests(userId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+    }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserHelper.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserHelper.java
@@ -19,9 +19,14 @@ public class UserHelper {
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
     }
 
-    public User getUserWithInformation(){
+
+    public User getUserWithInformation() {
         Long userId = SecurityUtils.getUserId();
-        return userRepository.findByIdWithAdditionsAndInterests(userId)
+        User user = userRepository.findByIdWithAdditions(userId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+
+        userRepository.findByIdWithInterests(userId);
+
+        return user;
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/code/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST,"USER4006","잘못된 비밀번호 입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST,"USER4007","비밀번호와 확인 비밀번호가 일치하지 않습니다."),
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST,"USER4008","기존 비밀번호와 같습니다."),
+    ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "USER4009", "온보딩 정보가 없습니다. 온보딩부터 완료해주세요."),
 
     //Policy
     CATEGORY_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POLICY5001", "존재하지 않는 정책 코드 입니다."),


### PR DESCRIPTION
## 연관 이슈

close #183 

<br/>

## 개요

사용자 정보 조회 API랑 사용자의 관심사를 조회하는 API 구현했습니다. (추천정책에서 필요)

<br/>

## ✅ 작업 내용

- 사용자 정보 조회 API
   
<img width="723" height="234" alt="image" src="https://github.com/user-attachments/assets/b3c40ca9-d3d3-4407-afde-2a0570d3850f" />

<img width="725" height="386" alt="image" src="https://github.com/user-attachments/assets/f7d5290e-c0cd-4bf0-9853-014f390fce75" />


- 사용자 관심사 조회 API
<img width="723" height="288" alt="image" src="https://github.com/user-attachments/assets/d2c36fc8-c3b5-4acb-9db9-3ed87f060b12" />


<br/>

### 📝 리팩토링 사항
추후 N+1문제 해결하기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**신규 기능**
- 프로필 정보 조회 기능 추가 (교육, 고용, 소득, 관심분야, 추가 정보)
- 관심분야 목록 조회 기능 추가

**버그 수정 / 개선**
- 온보딩 완료 상태 검증 로직 추가 및 미완료 시 명확한 오류 반환 (온보딩 관련 에러 코드/메시지)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->