### PR TITLE
[fix] 탈퇴, 로그아웃 오류

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
@@ -8,12 +8,13 @@ import chungbazi.chungbazi_be.domain.auth.service.AuthService;
 import chungbazi.chungbazi_be.domain.user.entity.enums.OAuthProvider;
 import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 
+@Tag(name = "[인증/인가]", description = "로그인, 로그아웃 등 인증, 인가 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
@@ -68,8 +68,7 @@ public class AuthController {
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API", description = "refresh Token 삭제하고 access Token 블랙리스트에 추가")
     public ApiResponse<String> logout() {
-        String token = (String) SecurityContextHolder.getContext().getAuthentication().getCredentials();
-        authService.logoutUser(token);
+        authService.logoutUser();
         return ApiResponse.onSuccess("Logout successful.");
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
@@ -76,10 +76,10 @@ public class AuthController {
     @DeleteMapping("/delete-account")
     @Operation(summary = "회원 탈퇴 API", description = "access Token을 블랙리스트에 추가하고 refresh Token 삭제, 회원 정보 삭제")
     public ApiResponse<String> deleteAccount() {
-        String token = (String) SecurityContextHolder.getContext().getAuthentication().getCredentials();
-        authService.deleteUserAccount(token);
+        authService.deleteUserAccount();
         return ApiResponse.onSuccess("Account deletion successful.");
     }
+
     @PostMapping("/reset-password")
     public ApiResponse<String> resetPassword(@RequestBody @Valid TokenRequestDTO.ResetPasswordRequestDTO request) {
         authService.resetPassword(request.getNewPassword());

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/exception/TokenBlacklistHandler.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/exception/TokenBlacklistHandler.java
@@ -1,0 +1,29 @@
+package chungbazi.chungbazi_be.domain.auth.exception;
+
+import chungbazi.chungbazi_be.global.apiPayload.ApiResponse;
+import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class TokenBlacklistHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public void handleBlacklistedToken(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> failureResponse = ApiResponse.onFailure(
+                ErrorStatus.INVALID_TOKEN.getCode(),
+                ErrorStatus.INVALID_TOKEN.getMessage(),
+                null
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(failureResponse));
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/jwt/JwtProvider.java
@@ -1,19 +1,16 @@
 package chungbazi.chungbazi_be.domain.auth.jwt;
 
-import chungbazi.chungbazi_be.domain.auth.service.CustomUserDetailsService;
 import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Date;
@@ -68,13 +65,22 @@ public class JwtProvider{
     }
 
     public String extractSubject(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    public Long getRemainingExpirationTime(String token) {
+        Claims claims = extractClaims(token);
+        long remainingTime = claims.getExpiration().getTime() - System.currentTimeMillis();
+        return Math.max(0, (remainingTime / 1000) + 1);
+    }
+
+    private Claims extractClaims(String token) {
         try {
-            Claims claims = Jwts.parserBuilder()
+            return Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
-            return claims.getSubject();
         } catch (ExpiredJwtException e) {
             throw new BadRequestHandler(ErrorStatus.EXPIRED_TOKEN);
         } catch (MalformedJwtException e) {

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/jwt/JwtTokenFilter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/jwt/JwtTokenFilter.java
@@ -1,5 +1,7 @@
 package chungbazi.chungbazi_be.domain.auth.jwt;
 
+import chungbazi.chungbazi_be.domain.auth.exception.TokenBlacklistHandler;
+import chungbazi.chungbazi_be.domain.auth.service.TokenAuthService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,19 +20,33 @@ import java.util.Collections;
 public class JwtTokenFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final TokenAuthService tokenAuthService;
+    private final TokenBlacklistHandler tokenBlacklistHandler;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
-            String token = resolveToken(request);
-            if (StringUtils.hasText(token)) {
-                jwtProvider.validateToken(token);
-                String userId = jwtProvider.extractSubject(token);
-                JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(
-                        userId, token, Collections.emptyList()
-                );
-                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token)) {
+            jwtProvider.validateToken(token);
+
+            // 로그아웃된 accessToken으로 로그인 시도 시, 예외 처리
+            if (tokenAuthService.isBlackListed(token)) {
+                SecurityContextHolder.clearContext();
+                tokenBlacklistHandler.handleBlacklistedToken(response);
+                return;
             }
+            String userId = jwtProvider.extractSubject(token);
+
+            JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(
+                    userId, token, Collections.emptyList()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        }
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -219,9 +219,9 @@ public class AuthService {
 
     // 로그아웃
     public void logoutUser(String token) {
-        tokenAuthService.validateNotBlackListed(token);
         Long userId = SecurityUtils.getUserId();
-        tokenAuthService.addToBlackList(token, "logout", 3600L);
+        Long remainingTime = jwtProvider.getRemainingExpirationTime(token);
+        tokenAuthService.addToBlackList(token, "logout", remainingTime);
         tokenAuthService.deleteRefreshToken(userId);
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -242,7 +242,6 @@ public class AuthService {
         return authConverter.toRefreshTokenResponse(token);
     }
 
-
     public boolean determineIsFirst(User user) {
         return !user.isSurveyStatus();
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -226,10 +226,8 @@ public class AuthService {
     }
 
     // 회원 탈퇴
-    public void deleteUserAccount(String token) {
-        tokenAuthService.validateNotBlackListed(token);
+    public void deleteUserAccount() {
         Long userId = SecurityUtils.getUserId();
-        tokenAuthService.addToBlackList(token, "delete-account", 3600L);
         tokenAuthService.deleteRefreshToken(userId);
         deleteUser(userId);
         fcmTokenService.deleteToken(userId);

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -219,9 +219,11 @@ public class AuthService {
     }
 
     // 로그아웃
-    public void logoutUser(String token) {
+    public void logoutUser() {
         Long userId = SecurityUtils.getUserId();
+        String token = (String) SecurityContextHolder.getContext().getAuthentication().getCredentials();
         Long remainingTime = jwtProvider.getRemainingExpirationTime(token);
+
         tokenAuthService.addToBlackList(token, "logout", remainingTime);
         tokenAuthService.deleteRefreshToken(userId);
     }

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHand
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -228,7 +229,12 @@ public class AuthService {
     // 회원 탈퇴
     public void deleteUserAccount() {
         Long userId = SecurityUtils.getUserId();
+        String accessToken = (String) SecurityContextHolder.getContext().getAuthentication().getCredentials();
+        Long remainingTime = jwtProvider.getRemainingExpirationTime(accessToken);
+
+        tokenAuthService.addToBlackList(accessToken, "delete-account", remainingTime);
         tokenAuthService.deleteRefreshToken(userId);
+
         deleteUser(userId);
         fcmTokenService.deleteToken(userId);
     }


### PR DESCRIPTION
## 연관 이슈

- close #185

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
- 탈퇴 및 로그아웃 오류 해결

> 로그아웃
> <img width="501" height="347" alt="image" src="https://github.com/user-attachments/assets/f08e04f8-bc26-4052-a95f-72a70d13a310" />

> 탈퇴
> <img width="562" height="335" alt="image" src="https://github.com/user-attachments/assets/5e229387-b693-4c7f-b3ca-485ec400ab10" />

> 로그아웃 및 탈퇴한 토큰으로 다른 API 호출
> <img width="506" height="350" alt="image" src="https://github.com/user-attachments/assets/50c6e774-7730-4727-abd3-bfab6ac14830" />

<br/>

## ✅ 작업 내용

- [x] 탈퇴 로직 수정
- [x] 로그아웃 로직 수정

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 탈퇴나 로그아웃을 했을 때 사용됐던 `accessToken`은 재사용되면 안되니 해당 토큰의 남은 시간 동안 사용 못하게 블랙리스트에 넣는 로직 + 만약 이 토큰으로 다른 API를 호출할 경우 유효하지 않은 토큰이라고 뜨게 예외 처리 했습니다.
- 오류의 정확한 원인은.... 저도 잘 모르겠으나.. 일단 불필요한 로직인 `tokenAuthService.validateNotBlackListed(token);`은 제거 했습니다.
- 만약 머지해도 똑같은 오류가 발생하면 현주님과 더 논의 해봐야 할 것 같습니다 ㅠ.ㅠ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 인증/인가 API 엔드포인트에 Swagger 문서화 추가

**버그 수정**
- 블랙리스트된 토큰에 대해 표준화된 401 Unauthorized 응답 반환
- 토큰 검증 프로세스에 블랙리스트 확인 단계 추가
- 토큰 만료 시간 계산 로직 개선

**리팩토링**
- 토큰 처리 로직 정리 및 에러 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->