### PR TITLE
[feat] 사용자 행동 데이터 수집 로그

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ dependencies {
 
     //Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.14.0'
 }
 //tasks.named('test') {
 //    useJUnitPlatform()

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenResponseDTO.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TokenResponseDTO {
 
+
     @Getter
     @AllArgsConstructor
     public static class LoginTokenResponseDTO {

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenResponseDTO.java
@@ -1,5 +1,6 @@
 package chungbazi.chungbazi_be.domain.auth.dto;
 
+import chungbazi.chungbazi_be.domain.user.support.UserIdentifier;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,6 +12,7 @@ public class TokenResponseDTO {
     @AllArgsConstructor
     public static class LoginTokenResponseDTO {
         private Long userId;
+        private String hashedUserId;
         private String userName;
         private Boolean isFirst;
         private String accessToken;
@@ -18,7 +20,8 @@ public class TokenResponseDTO {
         private long accessExp;
 
         public static LoginTokenResponseDTO of(Long userId, String userName, Boolean isFirst, String accessToken, String refreshToken, long accessExp) {
-            return new LoginTokenResponseDTO(userId, userName, isFirst, accessToken, refreshToken, accessExp);
+
+            return new LoginTokenResponseDTO(userId, UserIdentifier.hashUserId(userId), userName, isFirst, accessToken, refreshToken, accessExp);
         }
     }
 
@@ -26,6 +29,7 @@ public class TokenResponseDTO {
     @AllArgsConstructor
     public static class RefreshTokenResponseDTO {
         private Long userId;
+        private String hashedUserId;
         private String userName;
         private String accessToken;
         private String refreshToken;
@@ -38,7 +42,7 @@ public class TokenResponseDTO {
                 String refreshToken,
                 long accessExp
         ) {
-            return new RefreshTokenResponseDTO(userId, userName, accessToken, refreshToken, accessExp);
+            return new RefreshTokenResponseDTO(userId, UserIdentifier.hashUserId(userId), userName, accessToken, refreshToken, accessExp);
         }
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/entity/Policy.java
@@ -2,13 +2,7 @@ package chungbazi.chungbazi_be.domain.policy.entity;
 
 import chungbazi.chungbazi_be.domain.policy.dto.YouthPolicyResponse;
 import chungbazi.chungbazi_be.global.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.Set;
@@ -23,6 +17,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
+@Table(name = "policy", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_policy_biz_id", columnNames = {"biz_id"})
+})
 public class Policy extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/repository/PolicyRepository.java
@@ -26,4 +26,7 @@ public interface PolicyRepository extends JpaRepository<Policy, Long>, PolicyRep
     @Query("DELETE FROM Policy p " +
             "WHERE p.id IN :expiredPolicyIds")
     long deleteByIdIn(@Param("expiredPolicyIds") List<Long> expiredPolicyIds);
+
+    @Query("SELECT p.bizId FROM Policy p")
+    List<String> findAllBizIds();
 }

--- a/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/policy/service/PolicyService.java
@@ -17,8 +17,7 @@ import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import chungbazi.chungbazi_be.global.apiPayload.exception.GeneralException;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.BadRequestHandler;
 import chungbazi.chungbazi_be.global.apiPayload.exception.handler.NotFoundHandler;
-import chungbazi.chungbazi_be.global.utils.PaginationResult;
-import chungbazi.chungbazi_be.global.utils.PaginationUtil;
+import chungbazi.chungbazi_be.global.logging.TrackEvent;
 import chungbazi.chungbazi_be.global.utils.PopularSearch;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -54,6 +53,7 @@ public class PolicyService {
     }
 
     // 정책 검색
+    @TrackEvent(name = "search_policy")
     public PolicyListResponse getSearchPolicy(String name, String cursor, int size, String order) {
 
         User user = userHelper.getAuthenticatedUser();
@@ -88,6 +88,7 @@ public class PolicyService {
     }
 
     // 카테고리별 정책 조회
+    @TrackEvent(name = "filter_apply")
     public PolicyListResponse getCategoryPolicy(Category categoryName, String cursor, int size, String order) {
 
         User user = userHelper.getAuthenticatedUser();
@@ -109,6 +110,7 @@ public class PolicyService {
     }
 
     // 정책상세조회
+    @TrackEvent(name = "policy_detail_view")
     public PolicyDetailsResponse getPolicyDetails(Long policyId) {
 
         Policy policy = policyRepository.findById(policyId)

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/dto/request/UserRequestDTO.java
@@ -22,7 +22,7 @@ public class UserRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RegisterDto {
-        @NotNull
+
         @Schema(example = "서울시 강남구", description = "사용자의 지역")
         private Region region;
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserIdentifier.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserIdentifier.java
@@ -1,0 +1,25 @@
+package chungbazi.chungbazi_be.domain.user.support;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+public class UserIdentifier {
+
+    @Value("${logging.salt-key}")
+    private static String saltKey;
+
+    public static String hashUserId(Long userId) {
+        if (userId == null) return null;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            String rawInput = userId + saltKey;
+            byte[] encodedHash = digest.digest(rawInput.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(encodedHash);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserIdentifier.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserIdentifier.java
@@ -1,11 +1,13 @@
 package chungbazi.chungbazi_be.domain.user.support;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 
+@Component
 public class UserIdentifier {
 
     @Value("${logging.salt-key}")

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserIdentifier.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/support/UserIdentifier.java
@@ -13,6 +13,11 @@ public class UserIdentifier {
     @Value("${logging.salt-key}")
     private static String saltKey;
 
+    @Value("${logging.salt-key}")
+    public void setSaltKey(String saltKey) {
+        UserIdentifier.saltKey = saltKey;
+    }
+
     public static String hashUserId(Long userId) {
         if (userId == null) return null;
         try {

--- a/src/main/java/chungbazi/chungbazi_be/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/apiPayload/exception/ExceptionAdvice.java
@@ -6,7 +6,6 @@ import chungbazi.chungbazi_be.global.apiPayload.code.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -116,10 +115,5 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 errorCommonStatus.getHttpStatus(),
                 request
         );
-    }
-
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e, WebRequest request) {
-        return handleExceptionInternalConstraint(e, ErrorStatus.INVALID_NICKNAME, HttpHeaders.EMPTY, request);
     }
 }

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/LogTraceFilter.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/LogTraceFilter.java
@@ -1,0 +1,47 @@
+package chungbazi.chungbazi_be.global.logging;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.jboss.logging.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class LogTraceFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        try {
+            // 랜덤한 uuid 값을 생성하여 MDC 저장소에 request_id를 키, uuid를 value로 저장
+            UUID uuid = UUID.randomUUID();
+            MDC.put("trace_id", uuid.toString().substring(0, 8));
+
+            String entryPoint = httpRequest.getHeader("X-Entry-Point");
+            if (entryPoint == null) entryPoint = "DIRECT";
+            MDC.put("entry_point", entryPoint);
+
+            // 다음 필터로 제어 전달, 실제 요청이 로직이 실행되는 지점
+            chain.doFilter(request, response);
+        } finally {
+            // 실제 요청이 완료되면 MDC 저장소를 초기화
+            MDC.clear();
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/LogTraceFilter.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/LogTraceFilter.java
@@ -2,7 +2,7 @@ package chungbazi.chungbazi_be.global.logging;
 
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
-import org.jboss.logging.MDC;
+import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -27,7 +27,7 @@ public class LogTraceFilter implements Filter {
         try {
             // 랜덤한 uuid 값을 생성하여 MDC 저장소에 request_id를 키, uuid를 value로 저장
             UUID uuid = UUID.randomUUID();
-            MDC.put("trace_id", uuid.toString().substring(0, 8));
+            MDC.put("traceId", uuid.toString().substring(0, 8));
 
             String entryPoint = httpRequest.getHeader("X-Entry-Point");
             if (entryPoint == null) entryPoint = "DIRECT";

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/LogTraceFilter.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/LogTraceFilter.java
@@ -33,10 +33,9 @@ public class LogTraceFilter implements Filter {
             if (entryPoint == null) entryPoint = "DIRECT";
             MDC.put("entry_point", entryPoint);
 
-            // 다음 필터로 제어 전달, 실제 요청이 로직이 실행되는 지점
             chain.doFilter(request, response);
         } finally {
-            // 실제 요청이 완료되면 MDC 저장소를 초기화
+
             MDC.clear();
         }
     }

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/LoggingAspect.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/LoggingAspect.java
@@ -4,6 +4,7 @@ import chungbazi.chungbazi_be.domain.policy.dto.PolicyDetailsResponse;
 import chungbazi.chungbazi_be.domain.policy.dto.PolicyListResponse;
 import chungbazi.chungbazi_be.domain.user.entity.User;
 import chungbazi.chungbazi_be.domain.user.support.UserHelper;
+import chungbazi.chungbazi_be.domain.user.support.UserIdentifier;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -94,11 +95,11 @@ public class LoggingAspect {
             extraProperties.put("input_params", params);
             extraProperties.put("result_count", resultCount);
 
-            Long userId = null;
+            String hashedUserId = null;
             try {
                 User user = userHelper.getAuthenticatedUser();
                 if (user != null) {
-                    userId = user.getId();
+                    hashedUserId = UserIdentifier.hashUserId(user.getId());
                     extraProperties.put("user_income", user.getIncome()); // 소득분위
                     extraProperties.put("user_region", user.getRegion()); // 유저 지역
                     extraProperties.put("user_education", user.getEducation()); //유저 학력
@@ -118,7 +119,7 @@ public class LoggingAspect {
                     .traceId(MDC.get("trace_id"))
                     .entryPoint(eventName)
                     .timeStamp(LocalDateTime.now().toString())
-                    .userId(userId)
+                    .hashedUserId(hashedUserId)
                     .properties(extraProperties)
                     .build();
 
@@ -146,7 +147,8 @@ public class LoggingAspect {
 
     private int getResultCount(Object result) {
         if (result instanceof PolicyListResponse) {
-            return ((PolicyListResponse) result).getPolicies().size();
+            var policies = ((PolicyListResponse) result).getPolicies();
+            return policies != null ? policies.size() : 0;
         }
         return 0;
     }

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/LoggingAspect.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/LoggingAspect.java
@@ -87,7 +87,7 @@ public class LoggingAspect {
             int resultCount = getResultCount(result);
 
             // 검색 결과가 0개면 'empty_policy_result'로 이벤트명 변경
-            String finalEventName = (resultCount == 0 )
+            String finalEventName = (resultCount == 0 && result instanceof PolicyListResponse )
                     ? "empty_policy_result" : eventName;
 
             Map<String, Object> extraProperties = new HashMap<>();
@@ -101,7 +101,8 @@ public class LoggingAspect {
                     userId = user.getId();
                     extraProperties.put("user_income", user.getIncome()); // 소득분위
                     extraProperties.put("user_region", user.getRegion()); // 유저 지역
-                    extraProperties.put("user_education", user.getEducation()); // 유저 나이
+                    extraProperties.put("user_education", user.getEducation()); //유저 학력
+                    extraProperties.put("user_employment", user.getEmployment()); //유저 취업 상태
                 }
             } catch (Exception e) {
                 // 인증 정보가 없는 경우 무시

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/LoggingAspect.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/LoggingAspect.java
@@ -64,7 +64,6 @@ public class LoggingAspect {
     public Object around(ProceedingJoinPoint joinPoint, TrackEvent trackEvent) throws Throwable {
         long startTime = System.currentTimeMillis();
 
-        //메서드 실행 전: 파라미터(검색어, 필터값 등) 미리 추출
         Map<String, Object> params = getMethodParameters(joinPoint);
 
         Object result;
@@ -77,7 +76,6 @@ public class LoggingAspect {
 
             return result;
         } catch (Exception ex) {
-            // 에러 시 로깅 (필요 시)
             log.error("Event Method Error: {}", ex.getMessage());
             throw ex;
         }
@@ -88,7 +86,7 @@ public class LoggingAspect {
             // 결과 개수 추출 (PolicyListResponse 등에서)
             int resultCount = getResultCount(result);
 
-            // 검색 결과가 0개면 PM이 가장 중요하게 보는 'empty_policy_result'로 이벤트명 변경
+            // 검색 결과가 0개면 'empty_policy_result'로 이벤트명 변경
             String finalEventName = (resultCount == 0 )
                     ? "empty_policy_result" : eventName;
 

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/TrackEvent.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/TrackEvent.java
@@ -1,0 +1,12 @@
+package chungbazi.chungbazi_be.global.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackEvent {
+    String name();
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/UserEventLog.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/UserEventLog.java
@@ -8,7 +8,7 @@ import java.util.Map;
 public record UserEventLog(
         String eventName,
         String traceId,
-        Long userId,
+        String hashedUserId,
         String entryPoint,
         Map<String, Object> properties,
         String timeStamp

--- a/src/main/java/chungbazi/chungbazi_be/global/logging/UserEventLog.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/logging/UserEventLog.java
@@ -1,0 +1,16 @@
+package chungbazi.chungbazi_be.global.logging;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+@Builder
+public record UserEventLog(
+        String eventName,
+        String traceId,
+        Long userId,
+        String entryPoint,
+        Map<String, Object> properties,
+        String timeStamp
+) {
+}

--- a/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
@@ -20,7 +20,7 @@ public class PolicyScheduler {
     private final PolicyService policyService;
 
     //새로운 정책들 DB에 저장
-    @Scheduled(cron = "0 0 9  * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 5 20  * * *", zone = "Asia/Seoul")
     @Transactional
     public void policyFetch() {
         log.info("✅ 정책 스케줄러 실행 시작!");

--- a/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
+++ b/src/main/java/chungbazi/chungbazi_be/global/scheduler/PolicyScheduler.java
@@ -20,7 +20,7 @@ public class PolicyScheduler {
     private final PolicyService policyService;
 
     //새로운 정책들 DB에 저장
-    @Scheduled(cron = "0 5 20  * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 9  * * *", zone = "Asia/Seoul")
     @Transactional
     public void policyFetch() {
         log.info("✅ 정책 스케줄러 실행 시작!");

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/application-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>30</maxHistory>
+            <maxHistory>7</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
     </appender>
@@ -47,7 +47,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>30</maxHistory>
+            <maxHistory>7</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
     </appender>
@@ -60,7 +60,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/user-events-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
-            <maxHistory>90</maxHistory>
+            <maxHistory>30</maxHistory>
             <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
     </appender>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <property name="ENV" value="${spring.profiles.active:-default}" />
+
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr([%X{traceId}]){magenta} %clr([%-5level]) %clr(%logger{36}){cyan} - %msg%n" />
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{traceId}] [env=${ENV}] %-5level %logger{36} - %msg%n" />
     <!-- 콘솔 출력 설정 -->
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" class="class.org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} %highlight([%thread]) [env=${ENV}] %clr([%-5level]) %logger{36} - %msg%n
+                ${CONSOLE_LOG_PATTERN}
             </pattern>
         </encoder>
     </appender>
@@ -15,7 +22,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/application.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [env=${ENV}] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
 
         <!-- 로그 파일 롤링 정책 -->
@@ -35,7 +42,7 @@
         </filter>
 
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [env=${ENV}] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -45,6 +52,22 @@
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
     </appender>
+
+    <appender name="EVENT_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/user-events.log</file>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/user-events-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="USER_EVENT_LOGGER" level="INFO" additivity="false">
+        <appender-ref ref="EVENT_FILE" />
+        <appender-ref ref="CONSOLE" /> </logger>
 
     <!-- 루트 로거 설정 -->
     <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
     <!-- 콘솔 출력 설정 -->
     <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
     <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
-    <conversionRule conversionWord="wEx" class="class.org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -61,6 +61,7 @@
             <fileNamePattern>logs/user-events-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>90</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -9,7 +9,6 @@
     <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
     <conversionRule conversionWord="wEx" class="class.org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
 
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>


### PR DESCRIPTION
## 연관 이슈

close #172

<br/>

## 개요

사용자 행동 데이터를 수집하기 위한 로그 전략을 구축했습니다.
AOP를 이용하여 JSON 형태로 로그가 수집되도록 수정했으며,
PM님이 넘겨주신 구조에 맞게 구현했으니, 확인부탁드립니다!

<br/>

## ✅ 작업 내용

- [x] 로그 전략 재설계

<br/>

### 📝 논의사항

log-back 파일의 롤링정책 부분에서 최대 30일까지 로그 파일을 저장하도록 해뒀는데, 너무 긴 거 같아서 7일 정도로 줄일까 고민중입니다! 이에 대해서 의견 한번만 주시면 감사하겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 각 요청에 고유 추적 ID/진입 경로 추가 및 검색/필터/상세조회 이벤트 자동 추적, 전용 이벤트 로그 파일 생성
  * 인증 토큰에 익명화된 사용자 식별자(hashedUserId) 포함

* **개선 사항**
  * 이벤트 로그에 사용자 속성·결과 정보 포함으로 분석 강화
  * 정책 수집 시 기존 비즈니스ID 중복 방지 로직 추가

* **버그 수정**
  * 회원가입 시 지역(region) 필수 검증 제거

* **Chores**
  * Prometheus micrometer 의존성 버전 고정 (1.14.0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->