### PR TITLE
[feat] 로그인 타입 응답 추가

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/controller/AuthController.java
@@ -42,21 +42,21 @@ public class AuthController {
     @Operation(summary = "일반 사용자 로그인 API", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 생성")
     public ApiResponse<TokenResponseDTO.LoginTokenResponseDTO> loginUser(@Valid @RequestBody TokenRequestDTO.LoginTokenRequestDTO request) {
         TokenDTO token = authService.loginUser(request);
-        return ApiResponse.onSuccess(authService.createLoginTokenResponse(token));
+        return ApiResponse.onSuccess(authService.createLoginTokenResponse(token, OAuthProvider.LOCAL));
     }
 
     @PostMapping("/kakao-login")
     @Operation(summary = "사용자 등록 및 JWT 생성 API", description = "사용자 정보를 받아서 DB에 저장하고 JWT 토큰을 생성")
     public ApiResponse<TokenResponseDTO.LoginTokenResponseDTO> kakaoLoginUser(@Valid @RequestBody TokenRequestDTO.KakaoLoginTokenRequestDTO request) {
         TokenDTO token = authService.kakaolLoginUser(request,OAuthProvider.KAKAO);
-        return ApiResponse.onSuccess(authService.createLoginTokenResponse(token));
+        return ApiResponse.onSuccess(authService.createLoginTokenResponse(token, OAuthProvider.KAKAO));
     }
 
     @PostMapping("/apple-login")
     @Operation(summary = "Apple 로그인 API", description = "Apple idToken과 fcmToken으로 사용자 인증 후 JWT 토큰을 생성")
     public ApiResponse<TokenResponseDTO.LoginTokenResponseDTO> appleLoginUser(@Valid @RequestBody TokenRequestDTO.AppleLoginTokenRequestDTO request) {
         TokenDTO token = authService.appleLoginUser(request,OAuthProvider.APPLE);
-        return ApiResponse.onSuccess(authService.createLoginTokenResponse(token));
+        return ApiResponse.onSuccess(authService.createLoginTokenResponse(token, OAuthProvider.APPLE));
     }
 
     @PostMapping("/refresh-token")

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/converter/AuthConverter.java
@@ -2,19 +2,21 @@ package chungbazi.chungbazi_be.domain.auth.converter;
 
 import chungbazi.chungbazi_be.domain.auth.dto.TokenDTO;
 import chungbazi.chungbazi_be.domain.auth.dto.TokenResponseDTO;
+import chungbazi.chungbazi_be.domain.user.entity.enums.OAuthProvider;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AuthConverter {
 
-    public TokenResponseDTO.LoginTokenResponseDTO toLoginTokenResponse(TokenDTO token) {
+    public TokenResponseDTO.LoginTokenResponseDTO toLoginTokenResponse(TokenDTO token, OAuthProvider loginType) {
         return TokenResponseDTO.LoginTokenResponseDTO.of(
                 token.getUserId(),
                 token.getUserName(),
                 token.getIsFirst(),
                 token.getAccessToken(),
                 token.getRefreshToken(),
-                token.getAccessExp()
+                token.getAccessExp(),
+                loginType
         );
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/dto/TokenResponseDTO.java
@@ -1,5 +1,6 @@
 package chungbazi.chungbazi_be.domain.auth.dto;
 
+import chungbazi.chungbazi_be.domain.user.entity.enums.OAuthProvider;
 import chungbazi.chungbazi_be.domain.user.support.UserIdentifier;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,10 +20,11 @@ public class TokenResponseDTO {
         private String accessToken;
         private String refreshToken;
         private long accessExp;
+        private OAuthProvider loginType;
 
-        public static LoginTokenResponseDTO of(Long userId, String userName, Boolean isFirst, String accessToken, String refreshToken, long accessExp) {
+        public static LoginTokenResponseDTO of(Long userId, String userName, Boolean isFirst, String accessToken, String refreshToken, long accessExp, OAuthProvider loginType) {
 
-            return new LoginTokenResponseDTO(userId, UserIdentifier.hashUserId(userId), userName, isFirst, accessToken, refreshToken, accessExp);
+            return new LoginTokenResponseDTO(userId, UserIdentifier.hashUserId(userId), userName, isFirst, accessToken, refreshToken, accessExp, loginType);
         }
     }
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -242,8 +242,8 @@ public class AuthService {
     }
 
     // 응답
-    public TokenResponseDTO.LoginTokenResponseDTO createLoginTokenResponse(TokenDTO token) {
-        return authConverter.toLoginTokenResponse(token);
+    public TokenResponseDTO.LoginTokenResponseDTO createLoginTokenResponse(TokenDTO token, OAuthProvider loginType) {
+        return authConverter.toLoginTokenResponse(token, loginType);
     }
 
     public TokenResponseDTO.RefreshTokenResponseDTO createRefreshTokenResponse(TokenDTO token) {


### PR DESCRIPTION
## 연관 이슈

close #188

<br/>

## 개요

프론트 측의 요청사항으로 로그인 api 응답에 로그인 타입 필드 추가했습니다

<img width="870" height="109" alt="image" src="https://github.com/user-attachments/assets/21b38ab5-7d69-4c99-842c-8649f64c5811" />
테스트 결과 잘 뜨는 거 확인 했습니다

<br/>

## ✅ 작업 내용

- 로그인 타입 응답 추가

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 시 인증 제공자 정보(로컬, 카카오, 애플)를 응답에 포함하여 다중 OAuth 제공자 지원 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->