### PR TITLE
[fix] name null 허용

### DIFF
--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -190,7 +190,7 @@ public class AuthService {
     public User createUserForAppleLogin(String email, String appleUserId, OAuthProvider oAuthProvider) {
         User user = User.builder()
                 .email(email)
-                .name(appleUserId)
+                //.name(appleUserId)
                 .password("")
                 .oAuthProvider(oAuthProvider)
                 .build();

--- a/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/auth/service/AuthService.java
@@ -59,7 +59,6 @@ public class AuthService {
         User user = User.builder()
                 .email(request.getEmail())
                 .password(encodedPassword)
-                .name("닉네임을 등록해주세요.")
                 .oAuthProvider(OAuthProvider.LOCAL)
                 .build();
 

--- a/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
+++ b/src/main/java/chungbazi/chungbazi_be/domain/user/entity/User.java
@@ -30,7 +30,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String name;
 
     @Column(nullable = false, unique = true)


### PR DESCRIPTION
## 개요

프론트와 상의해본 결과 현재 로그인 과정에서 사용자가 이탈할 경우, name 제약 관련 문제가 있어 null 허용으로 수정했습니다.

<br/>

### 📝 논의사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경사항

* **기능 개선**
  * 회원 가입 시 닉네임 설정이 선택사항으로 변경되었습니다. 사용자는 가입 후 별도로 닉네임을 설정할 수 있습니다.
  * 애플 로그인 경로에서 자동 닉네임 할당이 제거되어, 애플로 가입 시 초기 닉네임이 비어있을 수 있습니다.
* **기타**
  * 사용자 이름 필드가 데이터베이스에서 NULL을 허용하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->